### PR TITLE
Trust ca android ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,19 @@ simply hook `window.open` during initialization.  For example:
         window.open = cordova.InAppBrowser.open;
     }
 
+# Additional Trusted Certificate Authority
+
 If you need to access any sites that use certificates which aren't normally
-trusted, such as self-signed certificates. You can force the InAppBrowser to
+trusted, such as self-signed certificates, you can force the InAppBrowser to
 trust them by saving the CA certificate (in DER format) to a file called
 `trusted-ca.der` in your `www` folder. The InAppBrowser will load the file and
 verify that all https URLs use a valid certificate (counting certificates
-issued by the CA you specified). This is an Android only feature.
+issued by the CA you specified).
+
+### Supported Platforms
+
+- Android
+- iOS
 
 ## cordova.InAppBrowser.open
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ simply hook `window.open` during initialization.  For example:
         window.open = cordova.InAppBrowser.open;
     }
 
+If you need to access any sites that use certificates which aren't normally
+trusted, such as self-signed certificates. You can force the InAppBrowser to
+trust them by saving the CA certificate (in DER format) to a file called
+`trusted-ca.der` in your `www` folder. The InAppBrowser will load the file and
+verify that all https URLs use a valid certificate (counting certificates
+issued by the CA you specified). This is an Android only feature.
+
 ## cordova.InAppBrowser.open
 
 Opens a URL in a new `InAppBrowser` instance, the current browser

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-plugin-inappbrowser-orcas",
-  "version": "1.3.0",
-  "description": "Cordova InAppBrowser Plugin",
+  "version": "1.4.2-dev",
+  "description": "Cordova InAppBrowser Plugin with additional certificate trust support",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-orcas",
     "platforms": [

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "cordova-plugin-inappbrowser",
-  "version": "1.4.1-dev",
+  "name": "cordova-plugin-inappbrowser-orcas",
+  "version": "1.3.0",
   "description": "Cordova InAppBrowser Plugin",
   "cordova": {
-    "id": "cordova-plugin-inappbrowser",
+    "id": "cordova-plugin-inappbrowser-orcas",
     "platforms": [
       "android",
       "amazon-fireos",
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/apache/cordova-plugin-inappbrowser"
+    "url": "https://github.com/orcasgit/cordova-plugin-inappbrowser"
   },
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,10 +20,10 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser-orcas"
-      version="1.3.0">
+      version="1.4.2-dev">
 
     <name>InAppBrowser</name>
-    <description>Cordova InAppBrowser Plugin</description>
+    <description>Cordova InAppBrowser Plugin with additional certificate trust support</description>
     <license>Apache 2.0</license>
     <keywords>cordova,in,app,browser,inappbrowser</keywords>
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-inappbrowser.git</repo>
@@ -125,10 +125,26 @@
             </feature>
         </config-file>
 
-        <header-file src="src/ios/CDVInAppBrowser.h" />
-	    <source-file src="src/ios/CDVInAppBrowser.m" />
 
-	    <framework src="CoreGraphics.framework" />
+        <header-file src="src/ios/CacheStoragePolicy.h" />
+        <header-file src="src/ios/CanonicalRequest.h" />
+        <header-file src="src/ios/CDVInAppBrowser.h" />
+        <header-file src="src/ios/CredentialsManager.h" />
+        <header-file src="src/ios/CustomHTTPProtocol.h" />
+        <header-file src="src/ios/QNSURLSessionDemux.h" />
+        <header-file src="src/ios/ThreadInfo.h" />
+        <header-file src="src/ios/WebViewController.h" />
+
+        <source-file src="src/ios/CacheStoragePolicy.m" />
+        <source-file src="src/ios/CanonicalRequest.m" />
+        <source-file src="src/ios/CDVInAppBrowser.m" />
+        <source-file src="src/ios/CredentialsManager.m" />
+        <source-file src="src/ios/CustomHTTPProtocol.m" />
+        <source-file src="src/ios/QNSURLSessionDemux.m" />
+        <source-file src="src/ios/ThreadInfo.m" />
+        <source-file src="src/ios/WebViewController.m" />
+
+        <framework src="CoreGraphics.framework" />
     </platform>
 
     <!-- wp7 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,8 @@
 -->
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="com.orcasinc.cordova.inappbrowser"
-      version="1.0.3">
+           id="cordova-plugin-inappbrowser-orcas"
+      version="1.3.0">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,8 @@
 -->
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="cordova-plugin-inappbrowser"
-      version="1.4.1-dev">
+           id="com.orcasinc.cordova.inappbrowser"
+      version="1.0.3">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>
@@ -40,7 +40,7 @@
             <clobbers target="window.open" />
         </js-module>
         <config-file target="res/xml/config.xml" parent="/*">
-            <feature name="InAppBrowser"> 
+            <feature name="InAppBrowser">
                 <param name="android-package" value="org.apache.cordova.inappbrowser.InAppBrowser"/>
             </feature>
         </config-file>
@@ -74,7 +74,7 @@
             <clobbers target="window.open" />
         </js-module>
         <config-file target="res/xml/config.xml" parent="/*">
-            <feature name="InAppBrowser"> 
+            <feature name="InAppBrowser">
                 <param name="android-package" value="org.apache.cordova.inappbrowser.InAppBrowser"/>
             </feature>
         </config-file>
@@ -82,24 +82,24 @@
         <source-file src="src/amazon/InAppBrowser.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppBrowserDialog.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/amazon/InAppChromeClient.java" target-dir="src/org/apache/cordova/inappbrowser" />
-        
+
         <!--  drawable src/android/resources -->
         <resource-file src="src/android/res/drawable-hdpi/ic_action_next_item.png" target="res/drawable-hdpi/ic_action_next_item.png" />
         <resource-file src="src/android/res/drawable-mdpi/ic_action_next_item.png" target="res/drawable-mdpi/ic_action_next_item.png" />
         <resource-file src="src/android/res/drawable-xhdpi/ic_action_next_item.png" target="res/drawable-xhdpi/ic_action_next_item.png" />
         <resource-file src="src/android/res/drawable-xxhdpi/ic_action_next_item.png" target="res/drawable-xxhdpi/ic_action_next_item.png" />
-        
+
         <resource-file src="src/android/res/drawable-hdpi/ic_action_previous_item.png" target="res/drawable-hdpi/ic_action_previous_item.png" />
         <resource-file src="src/android/res/drawable-mdpi/ic_action_previous_item.png" target="res/drawable-mdpi/ic_action_previous_item.png" />
         <resource-file src="src/android/res/drawable-xhdpi/ic_action_previous_item.png" target="res/drawable-xhdpi/ic_action_previous_item.png" />
         <resource-file src="src/android/res/drawable-xxhdpi/ic_action_previous_item.png" target="res/drawable-xxhdpi/ic_action_previous_item.png" />
-        
+
         <resource-file src="src/android/res/drawable-hdpi/ic_action_remove.png" target="res/drawable-hdpi/ic_action_remove.png" />
         <resource-file src="src/android/res/drawable-mdpi/ic_action_remove.png" target="res/drawable-mdpi/ic_action_remove.png" />
         <resource-file src="src/android/res/drawable-xhdpi/ic_action_remove.png" target="res/drawable-xhdpi/ic_action_remove.png" />
         <resource-file src="src/android/res/drawable-xxhdpi/ic_action_remove.png" target="res/drawable-xxhdpi/ic_action_remove.png" />
     </platform>
-    
+
     <!-- ubuntu -->
     <platform name="ubuntu">
         <js-module src="www/inappbrowser.js" name="inappbrowser">
@@ -118,16 +118,16 @@
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser.open" />
             <clobbers target="window.open" />
-        </js-module>  
+        </js-module>
         <config-file target="config.xml" parent="/*">
             <feature name="InAppBrowser">
-                <param name="ios-package" value="CDVInAppBrowser" /> 
+                <param name="ios-package" value="CDVInAppBrowser" />
             </feature>
         </config-file>
 
         <header-file src="src/ios/CDVInAppBrowser.h" />
 	    <source-file src="src/ios/CDVInAppBrowser.m" />
-	    
+
 	    <framework src="CoreGraphics.framework" />
     </platform>
 
@@ -159,7 +159,7 @@
         <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
             <Capability Name="ID_CAP_NETWORKING"/>
         </config-file>
-                
+
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser.open" />
             <clobbers target="window.open" />
@@ -199,7 +199,7 @@
         </js-module>
         <asset src="www/inappbrowser.css" target="css/inappbrowser.css" />
     </platform>
-  
+
     <!-- firefoxos -->
     <platform name="firefoxos">
         <config-file target="config.xml" parent="/*">

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -25,7 +25,9 @@ import android.provider.Browser;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.net.http.SslError;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
@@ -45,6 +47,8 @@ import android.webkit.HttpAuthHandler;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.webkit.SslErrorHandler;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -63,11 +67,28 @@ import org.apache.cordova.PluginResult;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.StringTokenizer;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 @SuppressLint("SetJavaScriptEnabled")
 public class InAppBrowser extends CordovaPlugin {
@@ -120,6 +141,16 @@ public class InAppBrowser extends CordovaPlugin {
             final HashMap<String, Boolean> features = parseFeature(args.optString(2));
 
             Log.d(LOG_TAG, "target = " + target);
+            Log.d(LOG_TAG, "url = " + url);
+
+            if(url.startsWith("https:")) {
+                // Trust any supplied certificate for SSL connections
+                try {
+                    addTrustedCA();
+                } catch (Exception e) {
+                    Log.d(LOG_TAG, "Unable to add trusted CA: " + e.toString());
+                }
+            }
 
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -781,12 +812,56 @@ public class InAppBrowser extends CordovaPlugin {
         }
     }
 
+    private void addTrustedCA() throws IOException, NoSuchAlgorithmException, CertificateException, KeyManagementException, KeyStoreException {
+        Log.d(LOG_TAG, "Adding trusted certificate if it exists");
+        // Load CAs from an InputStream
+        // (could be from a resource or ByteArrayInputStream or ...)
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        InputStream caInput;
+        try {
+            caInput = this.cordova.getActivity().getAssets().open("www/trusted-ca.der");
+        } catch (IOException ex) {
+            Log.d(LOG_TAG, "No trusted certificate authorities supplied: " + ex.toString());
+            return;
+        }
+        Log.d(LOG_TAG, "Found trusted certificate");
+        Certificate ca;
+        try {
+            ca = cf.generateCertificate(caInput);
+            Log.d(LOG_TAG, "ca=" + ((X509Certificate) ca).getSubjectDN());
+        } finally {
+            caInput.close();
+        }
+
+        // Create a KeyStore containing our trusted CAs
+        String keyStoreType = KeyStore.getDefaultType();
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        keyStore.load(null, null);
+        keyStore.setCertificateEntry("ca", ca);
+
+        // Create a TrustManager that trusts the CAs in our KeyStore
+        String tmfAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
+        tmf.init(keyStore);
+
+        // Create an SSLContext that uses our TrustManager
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, tmf.getTrustManagers(), null);
+
+        // Set up HttpsURLConnection so that default SSL connections use the
+        // socket factory we've made that trusts our certificate authority
+        Log.d(LOG_TAG, "Setting the default SSLSocketFactory");
+        HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+    }
+
     /**
      * The webview client receives notifications about appView
      */
     public class InAppBrowserClient extends WebViewClient {
         EditText edittext;
         CordovaWebView webView;
+        String currentUrl;
+        ArrayList<String> whiteList;
 
         /**
          * Constructor.
@@ -797,6 +872,49 @@ public class InAppBrowser extends CordovaPlugin {
         public InAppBrowserClient(CordovaWebView webView, EditText mEditText) {
             this.webView = webView;
             this.edittext = mEditText;
+            this.currentUrl = null;
+            this.whiteList = new ArrayList<String>();
+        }
+
+        /**
+         * Ignore SSL Certificate errors when the certificate is good with HttpsUrlConnection
+         */
+        @Override
+        public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+            Log.d(LOG_TAG, "We have received an SSL error on this URL: " + error.getUrl());
+            int endIndex = error.getUrl().indexOf("/", 8);
+            endIndex = endIndex == -1 ? (error.getUrl().length() - 1) : endIndex;
+            this.currentUrl = "https://" + error.getUrl().substring(8, endIndex);
+            Log.d(LOG_TAG, "We will verify the certificate on this URL: " + this.currentUrl);
+            if(this.whiteList.contains(this.currentUrl)) {
+                Log.d(LOG_TAG, "Already found the url in the white list, no need to verify it again");
+                handler.proceed();
+            } else {
+                Log.d(LOG_TAG, "The https url was not in the white list, we need to verify it");
+                new CheckSSLTask().execute(handler);
+            }
+        }
+
+        private class CheckSSLTask extends AsyncTask<SslErrorHandler, Void, Void> {
+            protected Void doInBackground(SslErrorHandler... handlers) {
+                try {
+                    HttpsURLConnection con = (HttpsURLConnection) new URL(currentUrl).openConnection();
+                    con.setConnectTimeout(5000);
+                    con.connect();
+                } catch (Exception ex) {
+                    Log.e(LOG_TAG, "Error with the site certificate: " + ex.toString());
+                    handlers[0].cancel();
+                }
+                // We have verified the certificate used by the site is trusted,
+                // white list the url and proceed to load the page
+                whiteList.add(currentUrl);
+                handlers[0].proceed();
+                return null;
+            }
+
+            protected void onPostExecute() {
+                currentUrl = null;
+            }
         }
 
         /**

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -17,6 +17,9 @@
  under the License.
  */
 
+#import "CredentialsManager.h"
+#import "CustomHTTPProtocol.h"
+#import "WebViewController.h"
 #import <Cordova/CDVPlugin.h>
 #import <Cordova/CDVInvokedUrlCommand.h>
 #import <Cordova/CDVScreenOrientationDelegate.h>
@@ -32,9 +35,23 @@
 @interface CDVInAppBrowser : CDVPlugin {
 }
 
+@property (nonatomic, strong, readwrite) CredentialsManager *   credentialsManager;
 @property (nonatomic, retain) CDVInAppBrowserViewController* inAppBrowserViewController;
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, copy) NSRegularExpression *callbackIdPattern;
+
+
+/*! For threadInfoByThreadID, each key is an NSNumber holding a thread ID and each
+ value is a ThreadInfo object.  The dictionary is protected by @synchronized on
+ the app delegate object itself.
+
+ In the debugger you can dump this info with:
+
+ (lldb) po [[[UIApplication sharedApplication] delegate] threadInfoByThreadID]
+ */
+
+@property (atomic, strong, readwrite) NSMutableDictionary *     threadInfoByThreadID;
+@property (atomic, assign, readwrite) NSUInteger                nextThreadNumber;           ///< Protected by @synchronized on the delegate object.
 
 - (void)open:(CDVInvokedUrlCommand*)command;
 - (void)close:(CDVInvokedUrlCommand*)command;
@@ -67,19 +84,19 @@
 
 @end
 
-@interface CDVInAppBrowserViewController : UIViewController <UIWebViewDelegate, CDVScreenOrientationDelegate>{
+@interface CDVInAppBrowserViewController : WebViewController <WebViewControllerDelegate, CustomHTTPProtocolDelegate, UIWebViewDelegate, CDVScreenOrientationDelegate>{
     @private
     NSString* _userAgent;
     NSString* _prevUserAgent;
     NSInteger _userAgentLockToken;
     CDVInAppBrowserOptions *_browserOptions;
-    
+
 #ifdef __CORDOVA_4_0_0
     CDVUIWebViewDelegate* _webViewDelegate;
 #else
     CDVWebViewDelegate* _webViewDelegate;
 #endif
-    
+
 }
 
 @property (nonatomic, strong) IBOutlet UIWebView* webView;
@@ -109,4 +126,3 @@
 @property (nonatomic, weak) id <CDVScreenOrientationDelegate> orientationDelegate;
 
 @end
-

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -17,9 +17,65 @@
  under the License.
  */
 
+// Significant code from AppDelegate.m in the Apple CustomHTTPProtocol example
+// was used here, so we have included the comment block below.
+
+/*
+ File: AppDelegate.m
+ Abstract: Main app controller.
+ Version: 1.1
+
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+
+ */
+
 #import "CDVInAppBrowser.h"
+#import "CredentialsManager.h"
+#import "CustomHTTPProtocol.h"
+#import "ThreadInfo.h"
+
 #import <Cordova/CDVPluginResult.h>
 #import <Cordova/CDVUserAgentUtil.h>
+
+#include <pthread.h>            // for pthread_threadid_np
 
 #define    kInAppBrowserTargetSelf @"_self"
 #define    kInAppBrowserTargetSystem @"_system"
@@ -40,6 +96,10 @@
 @end
 
 @implementation CDVInAppBrowser
+
+static BOOL sAppDelegateLoggingEnabled = YES;
+
+static NSTimeInterval sAppStartTime;            // since reference date
 
 - (void)pluginInitialize
 {
@@ -119,6 +179,14 @@
 {
     CDVInAppBrowserOptions* browserOptions = [CDVInAppBrowserOptions parseOptions:options];
 
+    // Initialization required for trusting an additional certificate
+    sAppStartTime = [NSDate timeIntervalSinceReferenceDate];
+    self.threadInfoByThreadID = [[NSMutableDictionary alloc] init];
+    (void) [self threadInfoForCurrentThread];
+    [CustomHTTPProtocol setDelegate:self];
+    [CustomHTTPProtocol start];
+    self.credentialsManager = [[CredentialsManager alloc] init];
+
     if (browserOptions.clearcache) {
         NSHTTPCookie *cookie;
         NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
@@ -142,6 +210,7 @@
     }
 
     if (self.inAppBrowserViewController == nil) {
+        // Initialize the in app browser window
         NSString* userAgent = [CDVUserAgentUtil originalUserAgent];
         NSString* overrideUserAgent = [self settingForKey:@"OverrideUserAgent"];
         NSString* appendUserAgent = [self settingForKey:@"AppendUserAgent"];
@@ -152,7 +221,22 @@
             userAgent = [userAgent stringByAppendingString: appendUserAgent];
         }
         self.inAppBrowserViewController = [[CDVInAppBrowserViewController alloc] initWithUserAgent:userAgent prevUserAgent:[self.commandDelegate userAgent] browserOptions: browserOptions];
+        [self.inAppBrowserViewController setDelegate:self];
         self.inAppBrowserViewController.navigationDelegate = self;
+
+        // Enable additional certificate authority, if it's there
+        NSURL* baseURL = [NSURL URLWithString:@"trusted-ca.der"];
+        NSString* certPath = [self.commandDelegate pathForResource:[baseURL path]];
+        if(certPath) {
+            NSData* certData = [NSData dataWithContentsOfFile:certPath];
+            NSError* error = nil;
+            [self.inAppBrowserViewController parseAndInstallCertificateData:certData error:&error];
+            if(error != nil) {
+                [self.inAppBrowserViewController logWithFormat:@"trusted anchor install did fail with error code %@ / %zd", [error domain], (ssize_t) [error code]];
+            } else {
+                [self.inAppBrowserViewController logWithFormat:@"trusted anchor install did finish"];
+            }
+        }
 
         if ([self.viewController conformsToProtocol:@protocol(CDVScreenOrientationDelegate)]) {
             self.inAppBrowserViewController.orientationDelegate = (UIViewController <CDVScreenOrientationDelegate>*)self.viewController;
@@ -401,7 +485,7 @@
             [self.commandDelegate sendPluginResult:pluginResult callbackId:scriptCallbackId];
             return NO;
         }
-    } 
+    }
     //if is an app store link, let the system handle it, otherwise it fails to load it
     else if ([[ url scheme] isEqualToString:@"itms-appss"] || [[ url scheme] isEqualToString:@"itms-apps"]) {
         [theWebView stopLoading];
@@ -472,6 +556,198 @@
     _previousStatusBarStyle = -1; // this value was reset before reapplying it. caused statusbar to stay black on ios7
 }
 
+
+
+- (BOOL)webViewController:(WebViewController *)controller addTrustedAnchor:(SecCertificateRef)anchor error:(NSError *__autoreleasing *)errorPtr
+{
+#pragma unused(controller)
+    assert(controller != nil);
+    assert(anchor != NULL);
+    // errorPtr may be NULL
+#pragma unused(errorPtr)
+    assert([NSThread isMainThread]);
+
+    [self.credentialsManager addTrustedAnchor:anchor];
+    return YES;
+}
+
+- (BOOL)customHTTPProtocol:(CustomHTTPProtocol *)protocol canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
+{
+    assert(protocol != nil);
+#pragma unused(protocol)
+    assert(protectionSpace != nil);
+
+    // We accept any server trust authentication challenges.
+
+    return [[protectionSpace authenticationMethod] isEqual:NSURLAuthenticationMethodServerTrust];
+}
+
+- (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+    OSStatus            err;
+    NSURLCredential *   credential;
+    SecTrustRef         trust;
+    SecTrustResultType  trustResult;
+
+    // Given our implementation of -customHTTPProtocol:canAuthenticateAgainstProtectionSpace:, this method
+    // is only called to handle server trust authentication challenges.  It evaluates the trust based on
+    // both the global set of trusted anchors and the list of trusted anchors returned by the CredentialsManager.
+
+    assert(protocol != nil);
+    assert(challenge != nil);
+    assert([[[challenge protectionSpace] authenticationMethod] isEqual:NSURLAuthenticationMethodServerTrust]);
+    assert([NSThread isMainThread]);
+
+    credential = nil;
+
+    // Extract the SecTrust object from the challenge, apply our trusted anchors to that
+    // object, and then evaluate the trust.  If it's OK, create a credential and use
+    // that to resolve the authentication challenge.  If anything goes wrong, resolve
+    // the challenge with nil, which continues without a credential, which causes the
+    // connection to fail.
+
+    trust = [[challenge protectionSpace] serverTrust];
+    if (trust == NULL) {
+        assert(NO);
+    } else {
+        err = SecTrustSetAnchorCertificates(trust, (__bridge CFArrayRef) self.credentialsManager.trustedAnchors);
+        if (err != noErr) {
+            assert(NO);
+        } else {
+            err = SecTrustSetAnchorCertificatesOnly(trust, false);
+            if (err != noErr) {
+                assert(NO);
+            } else {
+                err = SecTrustEvaluate(trust, &trustResult);
+                if (err != noErr) {
+                    assert(NO);
+                } else {
+                    if ( (trustResult == kSecTrustResultProceed) || (trustResult == kSecTrustResultUnspecified) ) {
+                        credential = [NSURLCredential credentialForTrust:trust];
+                        assert(credential != nil);
+                    }
+                }
+            }
+        }
+    }
+
+    [protocol resolveAuthenticationChallenge:challenge withCredential:credential];
+}
+
+- (ThreadInfo *)threadInfoForCurrentThread
+{
+    int             junk;
+    uint64_t        tid;
+    NSNumber *      tidObj;
+    ThreadInfo *    result;
+
+    // Get the thread ID and box it for use as a dictionary key.
+
+    junk = pthread_threadid_np(pthread_self(), &tid);
+#pragma unused(junk)            // quietens analyser in the Release build
+    assert(junk == 0);
+    tidObj = @(tid);
+
+    // Look up the thread info using that key.
+
+    @synchronized (self) {
+        result = self.threadInfoByThreadID[tidObj];
+    }
+
+    // If we didn't find one, create it.  We drop the @synchronized while doing this because
+    // it might take a while; in theory no one else should be able to add this thread into
+    // the dictionary (because threads only add themselves) so we just assert that this
+    // hasn't happened.
+    //
+    // Also note that, because self.nextThreadNumber accesses must be protected by the
+    // @synchronized, we actually created the ThreadInfo object inside the @synchronized
+    // block.  That shouldn't be a problem because -[ThreadInfo initXxx] is trivial.
+
+    if (result == nil) {
+        ThreadInfo *    newThreadInfo;
+        char            threadName[256];
+        NSString *      threadNameObj;
+
+        if ( (pthread_getname_np(pthread_self(), threadName, sizeof(threadName)) == 0) && (threadName[0] != 0) ) {
+            // We got a name and it's not empty.
+            threadNameObj = [[NSString alloc] initWithUTF8String:threadName];
+        } else if (pthread_main_np()) {
+            threadNameObj = @"-main-";
+        } else {
+            threadNameObj = @"-unnamed-";
+        }
+        assert(threadNameObj != nil);
+
+        @synchronized (self) {
+            assert(self.threadInfoByThreadID[tidObj] == nil);
+
+            newThreadInfo = [[ThreadInfo alloc] initWithThreadID:tid number:self.nextThreadNumber name:threadNameObj];
+            self.nextThreadNumber += 1;
+
+            self.threadInfoByThreadID[tidObj] = newThreadInfo;
+            result = newThreadInfo;
+        }
+    }
+
+    return result;
+}
+
+/*! Our logging core, called by various logging routines, each with a unique prefix. May be called
+ *  by any thread.
+ *  \param prefix A prefix to to insert into the log; must not be nil; if non-empty, should include a trailing space.
+ *  \param format A standard NSString-style format string.
+ *  \param arguments Arguments for that format string.
+ */
+
+- (void)logWithPrefix:(NSString *)prefix format:(NSString *)format arguments:(va_list)arguments
+{
+    assert(prefix != nil);
+    assert(format != nil);
+
+    if (sAppDelegateLoggingEnabled) {
+        NSTimeInterval  now;
+        ThreadInfo *    threadInfo;
+        NSString *      str;
+        char            elapsedStr[16];
+
+        now = [NSDate timeIntervalSinceReferenceDate];
+
+        threadInfo = [self threadInfoForCurrentThread];
+
+        str = [[NSString alloc] initWithFormat:format arguments:arguments];
+        assert(str != nil);
+
+        snprintf(elapsedStr, sizeof(elapsedStr), "+%.1f", (now - sAppStartTime));
+
+        fprintf(stderr, "%3zu %s %s%s\n", (size_t) threadInfo.number, elapsedStr, [prefix UTF8String], [str UTF8String]);
+    }
+}
+
+- (void)webViewController:(WebViewController *)controller logWithFormat:(NSString *)format arguments:(va_list)arguments
+{
+#pragma unused(controller)
+    assert(controller != nil);
+    assert(format != nil);
+    assert([NSThread isMainThread]);
+
+    [self logWithPrefix:@"web view " format:format arguments:arguments];
+}
+
+- (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol logWithFormat:(NSString *)format arguments:(va_list)arguments
+{
+    NSString *  prefix;
+
+    // protocol may be nil
+    assert(format != nil);
+
+    if (protocol == nil) {
+        prefix = @"protocol ";
+    } else {
+        prefix = [NSString stringWithFormat:@"protocol %p ", protocol];
+    }
+    [self logWithPrefix:prefix format:format arguments:arguments];
+}
+
 @end
 
 #pragma mark CDVInAppBrowserViewController
@@ -492,7 +768,7 @@
 #else
         _webViewDelegate = [[CDVWebViewDelegate alloc] initWithDelegate:self];
 #endif
-        
+
         [self createViews];
     }
 
@@ -1072,4 +1348,3 @@
 
 
 @end
-

--- a/src/ios/CacheStoragePolicy.h
+++ b/src/ios/CacheStoragePolicy.h
@@ -1,0 +1,61 @@
+/*
+     File: CacheStoragePolicy.h
+ Abstract: A function to determine the cache storage policy for a request.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+@import Foundation;
+
+/*! Determines the cache storage policy for a response.
+ *  \details When we provide a response up to the client we need to tell the client whether 
+ *  the response is cacheable or not.  The default HTTP/HTTPS protocol has a reasonable 
+ *  complex chunk of code to determine this, but we can't get at it.  Thus, we have to 
+ *  reimplement it ourselves.  This is split off into a separate file to emphasise that 
+ *  this is standard boilerplate that you probably don't need to look at.
+ *  \param request The request that generated the response; must not be nil.
+ *  \param response The response itself; must not be nil.
+ *  \returns A cache storage policy to use.
+ */
+
+extern NSURLCacheStoragePolicy CacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response);

--- a/src/ios/CacheStoragePolicy.m
+++ b/src/ios/CacheStoragePolicy.m
@@ -1,0 +1,124 @@
+/*
+     File: CacheStoragePolicy.m
+ Abstract: A function to determine the cache storage policy for a request.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import "CacheStoragePolicy.h"
+
+extern NSURLCacheStoragePolicy CacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response)
+    // See comment in header.
+{
+    BOOL                        cacheable;
+    NSURLCacheStoragePolicy     result;
+
+    assert(request != NULL);
+    assert(response != NULL);
+
+    // First determine if the request is cacheable based on its status code.
+    
+    switch ([response statusCode]) {
+        case 200:
+        case 203:
+        case 206:
+        case 301:
+        case 304:
+        case 404:
+        case 410: {
+            cacheable = YES;
+        } break;
+        default: {
+            cacheable = NO;
+        } break;
+    }
+
+    // If the response might be cacheable, look at the "Cache-Control" header in 
+    // the response.
+
+    // IMPORTANT: We can't rely on -rangeOfString: returning valid results if the target 
+    // string is nil, so we have to explicitly test for nil in the following two cases.
+    
+    if (cacheable) {
+        NSString *  responseHeader;
+        
+        responseHeader = [[response allHeaderFields][@"Cache-Control"] lowercaseString];
+        if ( (responseHeader != nil) && [responseHeader rangeOfString:@"no-store"].location != NSNotFound) {
+            cacheable = NO;
+        }
+    }
+
+    // If we still think it might be cacheable, look at the "Cache-Control" header in 
+    // the request.
+
+    if (cacheable) {
+        NSString *  requestHeader;
+
+        requestHeader = [[request allHTTPHeaderFields][@"Cache-Control"] lowercaseString];
+        if ( (requestHeader != nil) 
+          && ([requestHeader rangeOfString:@"no-store"].location != NSNotFound)
+          && ([requestHeader rangeOfString:@"no-cache"].location != NSNotFound) ) {
+            cacheable = NO;
+        }
+    }
+
+    // Use the cacheable flag to determine the result.
+    
+    if (cacheable) {
+    
+        // This code only caches HTTPS data in memory.  This is inline with earlier versions of 
+        // iOS.  Modern versions of iOS use file protection to protect the cache, and thus are 
+        // happy to cache HTTPS on disk.  I've not made the correspondencing change because 
+        // it's nice to see all three cache policies in action.
+    
+        if ([[[[request URL] scheme] lowercaseString] isEqual:@"https"]) {
+            result = NSURLCacheStorageAllowedInMemoryOnly;
+        } else {
+            result = NSURLCacheStorageAllowed;
+        }
+    } else {
+        result = NSURLCacheStorageNotAllowed;
+    }
+
+    return result;
+}

--- a/src/ios/CanonicalRequest.h
+++ b/src/ios/CanonicalRequest.h
@@ -1,0 +1,64 @@
+/*
+     File: CanonicalRequest.h
+ Abstract: A function for creating canonical HTTP/HTTPS requests.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+@import Foundation;
+
+/*! Returns a canonical form of the supplied request.
+ *  \details The Foundation URL loading system needs to be able to canonicalize URL 
+ *  requests for various reasons (for example, to look for cache hits).  The default 
+ *  HTTP/HTTPS protocol has a complex chunk of code to perform this function.  Unfortunately 
+ *  there's no way for third party code to access this.  Instead, we have to reimplement 
+ *  it all ourselves.  This is split off into a separate file to emphasise that this 
+ *  is standard boilerplate that you probably don't need to look at.
+ *  
+ *  IMPORTANT: While you can take most of this code as read, you might want to tweak 
+ *  the handling of the "Accept-Language" in the CanonicaliseHeaders routine.
+ *  \param request The request to canonicalise; must not be nil.
+ *  \returns The canonical request; should never be nil.
+ */
+
+extern NSMutableURLRequest * CanonicalRequestForRequest(NSURLRequest *request);

--- a/src/ios/CanonicalRequest.m
+++ b/src/ios/CanonicalRequest.m
@@ -1,0 +1,436 @@
+/*
+     File: CanonicalRequest.m
+ Abstract: A function for creating canonical HTTP/HTTPS requests.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import "CanonicalRequest.h"
+
+#include <xlocale.h>
+
+#pragma mark * URL canonicalization steps 
+
+/*! A step in the canonicalisation process.
+ *  \details The canonicalisation process is made up of a sequence of steps, each of which is 
+ *  implemented by a function that matches this function pointer.  The function gets a URL 
+ *  and a mutable buffer holding that URL as bytes.  The function can mutate the buffer as it 
+ *  sees fit.  It typically does this by calling CFURLGetByteRangeForComponent to find the range 
+ *  of interest in the buffer.  In that case bytesInserted is the amount to adjust that range, 
+ *  and the function should modify that to account for any bytes it inserts or deletes.  If 
+ *  the function modifies the buffer too much, it can return kCFNotFound to force the system 
+ *  to re-create the URL from the buffer.
+ *  \param url The original URL to work on.
+ *  \param urlData The URL as a mutable buffer; the routine modifies this.
+ *  \param bytesInserted The number of bytes that have been inserted so far the mutable buffer.
+ *  \returns An updated value of bytesInserted or kCFNotFound if the URL must be reparsed.
+ */
+
+typedef CFIndex (*CanonicalRequestStepFunction)(NSURL *url, NSMutableData *urlData, CFIndex bytesInserted);
+
+/*! The post-scheme separate should be "://"; if that's not the case, fix it.
+ *  \param url The original URL to work on.
+ *  \param urlData The URL as a mutable buffer; the routine modifies this.
+ *  \param bytesInserted The number of bytes that have been inserted so far the mutable buffer.
+ *  \returns An updated value of bytesInserted or kCFNotFound if the URL must be reparsed.
+ */
+
+static CFIndex FixPostSchemeSeparator(NSURL *url, NSMutableData *urlData, CFIndex bytesInserted)
+{
+    CFRange     range;
+    uint8_t *   urlDataBytes;
+    NSUInteger  urlDataLength;
+    NSUInteger  cursor;
+    NSUInteger  separatorLength;
+    NSUInteger  expectedSeparatorLength;
+    
+    assert(url != nil);
+    assert(urlData != nil);
+    assert(bytesInserted >= 0);
+
+    range = CFURLGetByteRangeForComponent( (CFURLRef) url, kCFURLComponentScheme, NULL);
+    if (range.location != kCFNotFound) {
+        assert(range.location >= 0);
+        assert(range.length >= 0);
+        
+        urlDataBytes  = [urlData mutableBytes];
+        urlDataLength = [urlData length];
+        
+        separatorLength = 0;
+        cursor = (NSUInteger) range.location + (NSUInteger) bytesInserted + (NSUInteger) range.length;
+        if ( (cursor < urlDataLength) && (urlDataBytes[cursor] == ':') ) {
+            cursor += 1;
+            separatorLength += 1;
+            if ( (cursor < urlDataLength) && (urlDataBytes[cursor] == '/') ) {
+                cursor += 1;
+                separatorLength += 1;
+                if ( (cursor < urlDataLength) && (urlDataBytes[cursor] == '/') ) {
+                    cursor += 1;
+                    separatorLength += 1;
+                }
+            }
+        }
+        #pragma unused(cursor)          // quietens an analyser warning
+                
+        expectedSeparatorLength = strlen("://");
+        if (separatorLength != expectedSeparatorLength) {
+            [urlData replaceBytesInRange:NSMakeRange((NSUInteger) range.location + (NSUInteger) bytesInserted + (NSUInteger) range.length, separatorLength) withBytes:"://" length:expectedSeparatorLength];
+            bytesInserted = kCFNotFound;        // have to build everything now
+        }
+    }
+    
+    return bytesInserted;
+}
+
+/*! The scheme should be lower case; if it's not, make it so.
+ *  \param url The original URL to work on.
+ *  \param urlData The URL as a mutable buffer; the routine modifies this.
+ *  \param bytesInserted The number of bytes that have been inserted so far the mutable buffer.
+ *  \returns An updated value of bytesInserted or kCFNotFound if the URL must be reparsed.
+ */
+
+static CFIndex LowercaseScheme(NSURL *url, NSMutableData *urlData, CFIndex bytesInserted)
+{
+    CFRange     range;
+    uint8_t *   urlDataBytes;
+    CFIndex     i;
+    
+    assert(url != nil);
+    assert(urlData != nil);
+    assert(bytesInserted >= 0);
+
+    range = CFURLGetByteRangeForComponent( (CFURLRef) url, kCFURLComponentScheme, NULL);
+    if (range.location != kCFNotFound) {
+        assert(range.location >= 0);
+        assert(range.length >= 0);
+
+        urlDataBytes = [urlData mutableBytes];
+        for (i = range.location + bytesInserted; i < (range.location + bytesInserted + range.length); i++) {
+            urlDataBytes[i] = (uint8_t) tolower_l(urlDataBytes[i], NULL);
+        }
+    }
+    return bytesInserted;
+}
+
+/*! The host should be lower case; if it's not, make it so.
+ *  \param url The original URL to work on.
+ *  \param urlData The URL as a mutable buffer; the routine modifies this.
+ *  \param bytesInserted The number of bytes that have been inserted so far the mutable buffer.
+ *  \returns An updated value of bytesInserted or kCFNotFound if the URL must be reparsed.
+ */
+
+static CFIndex LowercaseHost(NSURL *url, NSMutableData *urlData, CFIndex bytesInserted)
+    // The host should be lower case; if it's not, make it so.
+{
+    CFRange     range;
+    uint8_t *   urlDataBytes;
+    CFIndex     i;
+    
+    assert(url != nil);
+    assert(urlData != nil);
+    assert(bytesInserted >= 0);
+
+    range = CFURLGetByteRangeForComponent( (CFURLRef) url, kCFURLComponentHost, NULL);
+    if (range.location != kCFNotFound) {
+        assert(range.location >= 0);
+        assert(range.length >= 0);
+
+        urlDataBytes = [urlData mutableBytes];
+        for (i = range.location + bytesInserted; i < (range.location + bytesInserted + range.length); i++) {
+            urlDataBytes[i] = (uint8_t) tolower_l(urlDataBytes[i], NULL);
+        }
+    }
+    return bytesInserted;
+}
+
+/*! An empty host should be treated as "localhost" case; if it's not, make it so.
+ *  \param url The original URL to work on.
+ *  \param urlData The URL as a mutable buffer; the routine modifies this.
+ *  \param bytesInserted The number of bytes that have been inserted so far the mutable buffer.
+ *  \returns An updated value of bytesInserted or kCFNotFound if the URL must be reparsed.
+ */
+
+static CFIndex FixEmptyHost(NSURL *url, NSMutableData *urlData, CFIndex bytesInserted)
+{
+    CFRange     range;
+    CFRange     rangeWithSeparator;
+    
+    assert(url != nil);
+    assert(urlData != nil);
+    assert(bytesInserted >= 0);
+
+    range = CFURLGetByteRangeForComponent( (CFURLRef) url, kCFURLComponentHost, &rangeWithSeparator);
+    if (range.length == 0) {
+        NSUInteger  localhostLength;
+
+        assert(range.location >= 0);
+        assert(range.length >= 0);
+        
+        localhostLength = strlen("localhost");
+        if (range.location != kCFNotFound) {
+            [urlData replaceBytesInRange:NSMakeRange( (NSUInteger) range.location + (NSUInteger) bytesInserted, 0) withBytes:"localhost" length:localhostLength];
+            bytesInserted += localhostLength;
+        } else if ( (rangeWithSeparator.location != kCFNotFound) && (rangeWithSeparator.length == 0) ) {
+            [urlData replaceBytesInRange:NSMakeRange((NSUInteger) rangeWithSeparator.location + (NSUInteger) bytesInserted, 0) withBytes:"localhost" length:localhostLength];
+            bytesInserted += localhostLength;
+        }
+    }
+    return bytesInserted;
+}
+
+/*! Transform an empty URL path to "/".  For example, "http://www.apple.com" becomes "http://www.apple.com/".
+ *  \param url The original URL to work on.
+ *  \param urlData The URL as a mutable buffer; the routine modifies this.
+ *  \param bytesInserted The number of bytes that have been inserted so far the mutable buffer.
+ *  \returns An updated value of bytesInserted or kCFNotFound if the URL must be reparsed.
+ */
+
+static CFIndex FixEmptyPath(NSURL *url, NSMutableData *urlData, CFIndex bytesInserted)
+{
+    CFRange     range;
+    CFRange     rangeWithSeparator;
+    
+    assert(url != nil);
+    assert(urlData != nil);
+    assert(bytesInserted >= 0);
+
+    range = CFURLGetByteRangeForComponent( (CFURLRef) url, kCFURLComponentPath, &rangeWithSeparator);
+    // The following is not a typo.  We use rangeWithSeparator to find where to insert the 
+    // "/" and the range length to decide whether we /need/ to insert the "/".
+    if ( (rangeWithSeparator.location != kCFNotFound) && (range.length == 0) ) {
+        assert(range.location >= 0);
+        assert(range.length >= 0);
+        assert(rangeWithSeparator.location >= 0);
+        assert(rangeWithSeparator.length >= 0);
+
+        [urlData replaceBytesInRange:NSMakeRange( (NSUInteger) rangeWithSeparator.location + (NSUInteger) bytesInserted, 0) withBytes:"/" length:1];
+        bytesInserted += 1;
+    }
+    return bytesInserted;
+}
+
+/*! If the user specified the default port (80 for HTTP, 443 for HTTPS), remove it from the URL.
+ *  \details Actually this code is disabled because the equivalent code in the default protocol  
+ *  handler has also been disabled; some setups depend on get the port number in the URL, even if it 
+ *  is the default.
+ *  \param url The original URL to work on.
+ *  \param urlData The URL as a mutable buffer; the routine modifies this.
+ *  \param bytesInserted The number of bytes that have been inserted so far the mutable buffer.
+ *  \returns An updated value of bytesInserted or kCFNotFound if the URL must be reparsed.
+ */
+
+__attribute__((unused)) static CFIndex DeleteDefaultPort(NSURL *url, NSMutableData *urlData, CFIndex bytesInserted) 
+{
+    NSString *  scheme;
+    BOOL        isHTTP;
+    BOOL        isHTTPS;
+    CFRange     range;
+    uint8_t *   urlDataBytes;
+    NSString *  portNumberStr;
+    int         portNumber;
+
+    assert(url != nil);
+    assert(urlData != nil);
+    assert(bytesInserted >= 0);
+
+    scheme = [[url scheme] lowercaseString];
+    assert(scheme != nil);
+    
+    isHTTP  = [scheme isEqual:@"http" ];
+    isHTTPS = [scheme isEqual:@"https"];
+    
+    range = CFURLGetByteRangeForComponent( (CFURLRef) url, kCFURLComponentPort, NULL);
+    if (range.location != kCFNotFound) {
+        assert(range.location >= 0);
+        assert(range.length >= 0);
+
+        urlDataBytes = [urlData mutableBytes];
+        
+        portNumberStr = [[NSString alloc] initWithBytes:&urlDataBytes[range.location + bytesInserted] length:(NSUInteger) range.length encoding:NSUTF8StringEncoding];
+        if (portNumberStr != nil) {
+            portNumber = [portNumberStr intValue];
+            if ( (isHTTP && (portNumber == 80)) || (isHTTPS && (portNumber == 443)) ) {
+                // -1 and +1 to account for the leading ":"
+                [urlData replaceBytesInRange:NSMakeRange((NSUInteger) range.location + (NSUInteger) bytesInserted - 1, (NSUInteger) range.length + 1) withBytes:NULL length:0];
+                bytesInserted -= (range.length + 1);
+            }
+        }
+    }
+    return bytesInserted;
+}
+
+#pragma mark * Other request canonicalization
+
+/*! Canonicalise the request headers.
+ *  \param request The request to canonicalise.
+ */
+
+static void CanonicaliseHeaders(NSMutableURLRequest * request)
+{
+    // If there's no content type and the request is a POST with a body, add a default 
+    // content type of "application/x-www-form-urlencoded".
+    
+    if ( ([request valueForHTTPHeaderField:@"Content-Type"] == nil) 
+      && ([[request HTTPMethod] caseInsensitiveCompare:@"POST"] == NSOrderedSame) 
+      && (([request HTTPBody] != nil) || ([request HTTPBodyStream] != nil)) ) {
+        [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    }
+    
+    // If there's no "Accept" header, add a default.
+    
+    if ([request valueForHTTPHeaderField:@"Accept"] == nil) {
+        [request setValue:@"*/*" forHTTPHeaderField:@"Accept"];
+    }
+
+    // If there's not "Accept-Encoding" header, add a default.
+    
+    if ([request valueForHTTPHeaderField:@"Accept-Encoding"] == nil) {
+        [request setValue:@"gzip, deflate" forHTTPHeaderField:@"Accept-Encoding"];
+    }
+
+    // If there's not an "Accept-Language" headre, add a default.  This is quite bogus; ideally we 
+    // should derive the correct "Accept-Language" value from the langauge that the app is running 
+    // in.  However, that's quite difficult to get right, so rather than show some general purpose 
+    // code that might fail in some circumstances, I've decided to just hardwire US English. 
+    // If you use this code in your own app you can customise it as you see fit.  One option might be 
+    // to base this value on -[NSBundle preferredLocalizations], so that the web page comes back in 
+    // the language that the app is running in.
+    
+    if ([request valueForHTTPHeaderField:@"Accept-Language"] == nil) {
+        [request setValue:@"en-us" forHTTPHeaderField:@"Accept-Language"];
+    }
+}
+
+#pragma mark * API
+
+extern NSMutableURLRequest * CanonicalRequestForRequest(NSURLRequest *request)
+{
+    NSMutableURLRequest *   result;
+    NSString *              scheme;
+
+    assert(request != nil);
+
+    // Make a mutable copy of the request.
+    
+    result = [request mutableCopy];
+    
+    // First up check that we're dealing with HTTP or HTTPS.  If not, do nothing (why were we 
+    // we even called?).
+    
+    scheme = [[[request URL] scheme] lowercaseString];
+    assert(scheme != nil);
+    
+    if ( ! [scheme isEqual:@"http" ] && ! [scheme isEqual:@"https"]) {
+        assert(NO);
+    } else {
+        CFIndex         bytesInserted;
+        NSURL *         requestURL;
+        NSMutableData * urlData;
+        static const CanonicalRequestStepFunction kStepFunctions[] = {
+            FixPostSchemeSeparator, 
+            LowercaseScheme, 
+            LowercaseHost, 
+            FixEmptyHost, 
+            // DeleteDefaultPort,       -- The built-in canonicalizer has stopped doing this, so we don't do it either.
+            FixEmptyPath
+        };
+        size_t          stepIndex;
+        size_t          stepCount;
+        
+        // Canonicalise the URL by executing each of our step functions.
+        
+        bytesInserted = kCFNotFound;
+        urlData = nil;
+        requestURL = [request URL];
+        assert(requestURL != nil);
+
+        stepCount = sizeof(kStepFunctions) / sizeof(*kStepFunctions);
+        for (stepIndex = 0; stepIndex < stepCount; stepIndex++) {
+        
+            // If we don't have valid URL data, create it from the URL.
+            
+            assert(requestURL != nil);
+            if (bytesInserted == kCFNotFound) {
+                NSData *    urlDataImmutable;
+
+                urlDataImmutable = CFBridgingRelease( CFURLCreateData(NULL, (CFURLRef) requestURL, kCFStringEncodingUTF8, true) );
+                assert(urlDataImmutable != nil);
+                
+                urlData = [urlDataImmutable mutableCopy];
+                assert(urlData != nil);
+                
+                bytesInserted = 0;
+            }
+            assert(urlData != nil);
+            
+            // Run the step.
+            
+            bytesInserted = kStepFunctions[stepIndex](requestURL, urlData, bytesInserted);
+            
+            // Note: The following logging is useful when debugging this code.  Change the 
+            // if expression to YES to enable it.
+            
+            if (NO) {
+                fprintf(stderr, "  [%zu] %.*s\n", stepIndex, (int) [urlData length], (const char *) [urlData bytes]);
+            }
+            
+            // If the step invalidated our URL (or we're on the last step, whereupon we'll need 
+            // the URL outside of the loop), recreate the URL from the URL data.
+            
+            if ( (bytesInserted == kCFNotFound) || ((stepIndex + 1) == stepCount) ) {
+                requestURL = CFBridgingRelease( CFURLCreateWithBytes(NULL, [urlData bytes], (CFIndex) [urlData length], kCFStringEncodingUTF8, NULL) );
+                assert(requestURL != nil);
+                
+                urlData = nil;
+            }
+        }
+
+        [result setURL:requestURL];
+        
+        // Canonicalise the headers.
+        
+        CanonicaliseHeaders(result);
+    }
+    
+    return result;
+}

--- a/src/ios/CredentialsManager.h
+++ b/src/ios/CredentialsManager.h
@@ -1,0 +1,67 @@
+/*
+     File: CredentialsManager.h
+ Abstract: Manages the list of trusted anchor certificates.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+@import Foundation;
+
+/*! Manages the list of trusted anchor certificates.  This class is thread 
+ *  safe.
+ */
+
+@interface CredentialsManager : NSObject
+
+- (instancetype)init;
+
+@property (atomic, copy,   readonly ) NSArray *    trustedAnchors;       ///< The list of trusted anchor certificates; elements are of type SecCertificateRef; observable.
+
+/*! Adds a certificate to the end of the list of trusted anchor certificates.
+ *  Does nothing if the certificate is already in the list.
+ *  \param newAnchor The certificate to add; must not be NULL.
+ */
+
+- (void)addTrustedAnchor:(SecCertificateRef)newAnchor;
+
+@end

--- a/src/ios/CredentialsManager.m
+++ b/src/ios/CredentialsManager.m
@@ -1,0 +1,110 @@
+/*
+     File: CredentialsManager.m
+ Abstract: Manages the list of trusted anchor certificates.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import "CredentialsManager.h"
+
+@import Security;
+
+@interface CredentialsManager ()
+
+@property (atomic, strong, readonly ) NSMutableArray *   mutableTrustedAnchors;
+
+@end
+
+@implementation CredentialsManager
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self != nil) {
+        self->_mutableTrustedAnchors = [[NSMutableArray alloc] init];
+        assert(self->_mutableTrustedAnchors != nil);
+    }
+    return self;
+}
+
+- (NSArray *)trustedAnchors
+{
+    NSArray *   result;
+
+    @synchronized (self) {
+        result = [self->_mutableTrustedAnchors copy];
+        assert(result != nil);
+    }
+    return result;
+}
+
+- (void)addTrustedAnchor:(SecCertificateRef)newAnchor
+{
+    BOOL        found;
+    
+    assert(newAnchor != NULL);
+    
+    @synchronized (self) {
+        
+        // Check to see if the certificate is already in the mutableTrustedAnchors 
+        // array.  Somewhere along the line SecCertificate refs started supporting 
+        // CFEqual, so we can use -indexOfObject:, which is nice.
+        
+        found = [self->_mutableTrustedAnchors indexOfObject:(__bridge id) newAnchor] != NSNotFound;
+        
+        // If the new anchor isn't already in the array, add it.
+        
+        if ( ! found ) {
+            NSIndexSet *    indexSet;
+            
+            indexSet = [NSIndexSet indexSetWithIndex:[self->_mutableTrustedAnchors count]];
+            assert(indexSet != nil);
+            
+            [self willChange:NSKeyValueChangeInsertion valuesAtIndexes:indexSet forKey:@"trustedAnchors"];
+            [self->_mutableTrustedAnchors addObject:(__bridge id)newAnchor];
+            [self  didChange:NSKeyValueChangeInsertion valuesAtIndexes:indexSet forKey:@"trustedAnchors"];
+        }
+    }
+}
+
+@end

--- a/src/ios/CustomHTTPProtocol.h
+++ b/src/ios/CustomHTTPProtocol.h
@@ -1,0 +1,174 @@
+/*
+     File: CustomHTTPProtocol.h
+ Abstract: An NSURLProtocol subclass that overrides the built-in HTTP/HTTPS protocol.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+@import Foundation;
+
+@protocol CustomHTTPProtocolDelegate;
+
+/*! An NSURLProtocol subclass that overrides the built-in HTTP/HTTPS protocol to intercept 
+ *  authentication challenges for subsystems, ilke UIWebView, that don't otherwise allow it.  
+ *  To use this class you should set up your delegate (+setDelegate:) and then call +start. 
+ *  If you don't call +start the class is completely benign.
+ *
+ *  The really tricky stuff here is related to the authentication challenge delegate 
+ *  callbacks; see the docs for CustomHTTPProtocolDelegate for the details.
+ */
+
+@interface CustomHTTPProtocol : NSURLProtocol
+
+/*! Call this to start the module.  Prior to this the module is just dormant, and 
+ *  all HTTP requests proceed as normal.  After this all HTTP and HTTPS requests 
+ *  go through this module.
+ */
+
++ (void)start;
+
+/*! Sets the delegate for the class.
+ *  \details Note that there's one delegate for the entire class, not one per 
+ *  instance of the class as is more normal.  The delegate is not retained in general, 
+ *  but is retained for the duration of any given call.  Once you set the delegate to nil 
+ *  you can be assured that it won't be called unretained (that is, by the time that 
+ *  -setDelegate: returns, we've already done all possible retains on the delegate).
+ *  \param newValue The new delegate to use; may be nil.
+ */
+
++ (void)setDelegate:(id<CustomHTTPProtocolDelegate>)newValue;
+
+/*! Returns the class delegate.
+ */
+
++ (id<CustomHTTPProtocolDelegate>)delegate;
+
+@property (atomic, strong, readonly ) NSURLAuthenticationChallenge *    pendingChallenge;   ///< The current authentication challenge; it's only safe to access this from the main thread.
+
+/*! Call this method to resolve an authentication challeng.  This must be called on the main thread.
+ *  \param challenge The challenge to resolve. This must match the pendingChallenge property.
+ *  \param credential The credential to use, or nil to continue without a credential.
+ */
+
+- (void)resolveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge withCredential:(NSURLCredential *)credential;
+
+@end
+
+/*! The delegate for the CustomHTTPProtocol class (not its instances).
+ *  \details The delegate handles two different types of callbacks:
+ *
+ *  - authentication challenges
+ * 
+ *  - logging
+ *
+ *  The latter is very simple.  The former is quite tricky.  The basic idea is that each CustomHTTPProtocol 
+ *  instance sends the delegate a serialised stream of authentication challenges, each of which it is 
+ *  expected to resolve.  The sequence is as follows:
+ *
+ *  -# It calls -customHTTPProtocol:canAuthenticateAgainstProtectionSpace: to determine if the delegate 
+ *     can handle the challenge.  This can be call on an arbitrary background thread.
+ *
+ *  -# If the delegate returns YES, it calls -customHTTPProtocol:didReceiveAuthenticationChallenge: to 
+ *     actually process the challenge.  This is always called on the main thread.  The delegate can resolve 
+ *     the challenge synchronously (that is, before returning from the call) or it can return from the call 
+ *     and then, later on, resolve the challenge.  Resolving the challenge involves calling 
+ *     -[CustomHTTPProtocol resolveAuthenticationChallenge:withCredential:], which also must be called 
+ *     on the main thread.  Between the calls to -customHTTPProtocol:didReceiveAuthenticationChallenge: 
+ *     and -[CustomHTTPProtocol resolveAuthenticationChallenge:withCredential:], the protocol's 
+ *     pendingChallenge property will contain the challenge.
+ *
+ *  -# While there is a pending challenge, the protocol may call -customHTTPProtocol:didCancelAuthenticationChallenge: 
+ *     to cancel the challenge.  This is always called on the main thread.
+ *
+ *  Note that this design follows the original NSURLConnection model, not the newer NSURLConnection model 
+ *  (introduced in OS X 10.7 / iOS 5) or the NSURLSession model, because of my concerns about performance.  
+ *  Specifically, -customHTTPProtocol:canAuthenticateAgainstProtectionSpace: can be called on any thread 
+ *  but -customHTTPProtocol:didReceiveAuthenticationChallenge: is called on the main thread.  If I unified 
+ *  them I'd end up calling the resulting single routine on the main thread, which meanings a lot more 
+ *  bouncing between threads, much of which would be pointless in the common case where you don't want to 
+ *  customise the default behaviour.  Alternatively I could call the unified routine on an arbitrary thread, 
+ *  but that would make it harder for clients and require a major rework of my implementation.
+ */
+
+@protocol CustomHTTPProtocolDelegate <NSObject>
+
+@optional
+
+/*! Called by an CustomHTTPProtocol instance to ask the delegate whether it's prepared to handle 
+ *  a particular authentication challenge.  Can be called on any thread.
+ *  \param protocol The protocol instance itself; will not be nil.
+ *  \param protectionSpace The protection space for the authentication challenge; will not be nil.
+ *  \returns Return YES if you want the -customHTTPProtocol:didReceiveAuthenticationChallenge: delegate 
+ *  callback, or NO for the challenge to be handled in the default way.
+ */
+
+- (BOOL)customHTTPProtocol:(CustomHTTPProtocol *)protocol canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace;
+
+/*! Called by an CustomHTTPProtocol instance to request that the delegate process on authentication 
+ *  challenge. Will be called on the main thread. Unless the challenge is cancelled (see below) 
+ *  the delegate must eventually resolve it by calling -resolveAuthenticationChallenge:withCredential:.
+ *  \param protocol The protocol instance itself; will not be nil.
+ *  \param challenge The authentication challenge; will not be nil.
+ */
+
+- (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge;
+
+/*! Called by an CustomHTTPProtocol instance to cancel an issued authentication challenge.
+ *  Will be called on the main thread.
+ *  \param protocol The protocol instance itself; will not be nil.
+ *  \param challenge The authentication challenge; will not be nil; will match the challenge 
+ *  previously issued by -customHTTPProtocol:canAuthenticateAgainstProtectionSpace:.
+ */
+
+- (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol didCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge;
+
+/*! Called by the CustomHTTPProtocol to log various bits of information. 
+ *  Can be called on any thread.
+ *  \param protocol The protocol instance itself; nil to indicate log messages from the class itself.
+ *  \param format A standard NSString-style format string; will not be nil.
+ *  \param arguments Arguments for that format string.
+ */
+
+- (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol logWithFormat:(NSString *)format arguments:(va_list)arguments;
+
+@end

--- a/src/ios/CustomHTTPProtocol.m
+++ b/src/ios/CustomHTTPProtocol.m
@@ -1,0 +1,767 @@
+/*
+     File: CustomHTTPProtocol.m
+ Abstract: An NSURLProtocol subclass that overrides the built-in HTTP/HTTPS protocol.
+  Version: 1.1
+
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+
+ */
+
+#import "CustomHTTPProtocol.h"
+
+#import "CanonicalRequest.h"
+#import "CacheStoragePolicy.h"
+#import "QNSURLSessionDemux.h"
+
+// I use the following typedef to keep myself sane in the face of the wacky
+// Objective-C block syntax.
+
+typedef void (^ChallengeCompletionHandler)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * credential);
+
+@interface CustomHTTPProtocol () <NSURLSessionDataDelegate>
+
+@property (atomic, strong, readwrite) NSThread *                        clientThread;       ///< The thread on which we should call the client.
+
+/*! The run loop modes in which to call the client.
+ *  \details The concurrency control here is complex.  It's set up on the client
+ *  thread in -startLoading and then never modified.  It is, however, read by code
+ *  running on other threads (specifically the main thread), so we deallocate it in
+ *  -dealloc rather than in -stopLoading.  We can be sure that it's not read before
+ *  it's set up because the main thread code that reads it can only be called after
+ *  -startLoading has started the connection running.
+ */
+
+@property (atomic, copy,   readwrite) NSArray *                         modes;
+@property (atomic, assign, readwrite) NSTimeInterval                    startTime;          ///< The start time of the request; written by client thread only; read by any thread.
+@property (atomic, strong, readwrite) NSURLSessionDataTask *            task;               ///< The NSURLSession task for that request; client thread only.
+@property (atomic, strong, readwrite) NSURLAuthenticationChallenge *    pendingChallenge;
+@property (atomic, copy,   readwrite) ChallengeCompletionHandler        pendingChallengeCompletionHandler;  ///< The completion handler that matches pendingChallenge; main thread only.
+
+@end
+
+@implementation CustomHTTPProtocol
+
+#pragma mark * Subclass specific additions
+
+/*! The backing store for the class delegate.  This is protected by @synchronized on the class.
+ */
+
+static id<CustomHTTPProtocolDelegate> sDelegate;
+
++ (void)start
+{
+    [NSURLProtocol registerClass:self];
+}
+
++ (id<CustomHTTPProtocolDelegate>)delegate
+{
+    id<CustomHTTPProtocolDelegate> result;
+
+    @synchronized (self) {
+        result = sDelegate;
+    }
+    return result;
+}
+
++ (void)setDelegate:(id<CustomHTTPProtocolDelegate>)newValue
+{
+    @synchronized (self) {
+        sDelegate = newValue;
+    }
+}
+
+/*! Returns the session demux object used by all the protocol instances.
+ *  \details This object allows us to have a single NSURLSession, with a session delegate,
+ *  and have its delegate callbacks routed to the correct protocol instance on the correct
+ *  thread in the correct modes.  Can be called on any thread.
+ */
+
++ (QNSURLSessionDemux *)sharedDemux
+{
+    static dispatch_once_t      sOnceToken;
+    static QNSURLSessionDemux * sDemux;
+    dispatch_once(&sOnceToken, ^{
+        NSURLSessionConfiguration *     config;
+
+        config = [NSURLSessionConfiguration defaultSessionConfiguration];
+        // You have to explicitly configure the session to use your own protocol subclass here
+        // otherwise you don't see redirects <rdar://problem/17384498>.
+        config.protocolClasses = @[ self ];
+        sDemux = [[QNSURLSessionDemux alloc] initWithConfiguration:config];
+    });
+    return sDemux;
+}
+
+/*! Called by by both class code and instance code to log various bits of information.
+ *  Can be called on any thread.
+ *  \param protocol The protocol instance; nil if it's the class doing the logging.
+ *  \param format A standard NSString-style format string; will not be nil.
+ */
+
++ (void)customHTTPProtocol:(CustomHTTPProtocol *)protocol logWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(2, 3)
+    // All internal logging calls this routine, which routes the log message to the
+    // delegate.
+{
+    // protocol may be nil
+    id<CustomHTTPProtocolDelegate> strongDelegate;
+
+    strongDelegate = [self delegate];
+    if ([strongDelegate respondsToSelector:@selector(customHTTPProtocol:logWithFormat:arguments:)]) {
+        va_list arguments;
+
+        va_start(arguments, format);
+        [strongDelegate customHTTPProtocol:protocol logWithFormat:format arguments:arguments];
+        va_end(arguments);
+    }
+}
+
+#pragma mark * NSURLProtocol overrides
+
+/*! Used to mark our recursive requests so that we don't try to handle them (and thereby
+ *  suffer an infinite recursive death).
+ */
+
+static NSString * kOurRecursiveRequestFlagProperty = @"com.apple.dts.CustomHTTPProtocol";
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request
+{
+    BOOL        shouldAccept;
+    NSURL *     url;
+    NSString *  scheme;
+
+    // Check the basics.  This routine is extremely defensive because experience has shown that
+    // it can be called with some very odd requests <rdar://problem/15197355>.
+
+    shouldAccept = (request != nil);
+    if (shouldAccept) {
+        url = [request URL];
+        shouldAccept = (url != nil);
+    }
+    if ( ! shouldAccept ) {
+        [self customHTTPProtocol:nil logWithFormat:@"decline request (malformed)"];
+    }
+
+    // Decline our recursive requests.
+
+    if (shouldAccept) {
+        shouldAccept = ([self propertyForKey:kOurRecursiveRequestFlagProperty inRequest:request] == nil);
+        if ( ! shouldAccept ) {
+            [self customHTTPProtocol:nil logWithFormat:@"decline request %@ (recursive)", url];
+        }
+    }
+
+    // Get the scheme.
+
+    if (shouldAccept) {
+        scheme = [[url scheme] lowercaseString];
+        shouldAccept = (scheme != nil);
+
+        if ( ! shouldAccept ) {
+            [self customHTTPProtocol:nil logWithFormat:@"decline request %@ (no scheme)", url];
+        }
+    }
+
+    // Look for "http" or "https".
+    //
+    // Flip either or both of the following to YESes to control which schemes go through this custom
+    // NSURLProtocol subclass.
+
+    if (shouldAccept) {
+        shouldAccept = NO && [scheme isEqual:@"http"];
+        if ( ! shouldAccept ) {
+            shouldAccept = YES && [scheme isEqual:@"https"];
+        }
+
+        if ( ! shouldAccept ) {
+            [self customHTTPProtocol:nil logWithFormat:@"decline request %@ (scheme mismatch)", url];
+        } else {
+            [self customHTTPProtocol:nil logWithFormat:@"accept request %@", url];
+        }
+    }
+
+    return shouldAccept;
+}
+
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
+{
+    NSURLRequest *      result;
+
+    assert(request != nil);
+    // can be called on any thread
+
+    // Canonicalising a request is quite complex, so all the heavy lifting has
+    // been shuffled off to a separate module.
+
+    result = CanonicalRequestForRequest(request);
+
+    [self customHTTPProtocol:nil logWithFormat:@"canonicalized %@ to %@", [request URL], [result URL]];
+
+    return result;
+}
+
+- (id)initWithRequest:(NSURLRequest *)request cachedResponse:(NSCachedURLResponse *)cachedResponse client:(id <NSURLProtocolClient>)client
+{
+    assert(request != nil);
+    // cachedResponse may be nil
+    assert(client != nil);
+    // can be called on any thread
+
+    self = [super initWithRequest:request cachedResponse:cachedResponse client:client];
+    if (self != nil) {
+        // All we do here is log the call.
+        [[self class] customHTTPProtocol:self logWithFormat:@"init for %@ from <%@ %p>", [request URL], [client class], client];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    // can be called on any thread
+    [[self class] customHTTPProtocol:self logWithFormat:@"dealloc"];
+    assert(self->_task == nil);                     // we should have cleared it by now
+    assert(self->_pendingChallenge == nil);         // we should have cancelled it by now
+    assert(self->_pendingChallengeCompletionHandler == nil);    // we should have cancelled it by now
+}
+
+- (void)startLoading
+{
+    NSMutableURLRequest *   recursiveRequest;
+    NSMutableArray *        calculatedModes;
+    NSString *              currentMode;
+
+    // At this point we kick off the process of loading the URL via NSURLSession.
+    // The thread that calls this method becomes the client thread.
+
+    assert(self.clientThread == nil);           // you can't call -startLoading twice
+    assert(self.task == nil);
+
+    // Calculate our effective run loop modes.  In some circumstances (yes I'm looking at
+    // you UIWebView!) we can be called from a non-standard thread which then runs a
+    // non-standard run loop mode waiting for the request to finish.  We detect this
+    // non-standard mode and add it to the list of run loop modes we use when scheduling
+    // our callbacks.  Exciting huh?
+    //
+    // For debugging purposes the non-standard mode is "WebCoreSynchronousLoaderRunLoopMode"
+    // but it's better not to hard-code that here.
+
+    assert(self.modes == nil);
+    calculatedModes = [NSMutableArray array];
+    [calculatedModes addObject:NSDefaultRunLoopMode];
+    currentMode = [[NSRunLoop currentRunLoop] currentMode];
+    if ( (currentMode != nil) && ! [currentMode isEqual:NSDefaultRunLoopMode] ) {
+        [calculatedModes addObject:currentMode];
+    }
+    self.modes = calculatedModes;
+    assert([self.modes count] > 0);
+
+    // Create new request that's a clone of the request we were initialised with,
+    // except that it has our 'recursive request flag' property set on it.
+
+    recursiveRequest = [[self request] mutableCopy];
+    assert(recursiveRequest != nil);
+
+    [[self class] setProperty:@YES forKey:kOurRecursiveRequestFlagProperty inRequest:recursiveRequest];
+
+    self.startTime = [NSDate timeIntervalSinceReferenceDate];
+    if (currentMode == nil) {
+        [[self class] customHTTPProtocol:self logWithFormat:@"start %@", [recursiveRequest URL]];
+    } else {
+        [[self class] customHTTPProtocol:self logWithFormat:@"start %@ (mode %@)", [recursiveRequest URL], currentMode];
+    }
+
+    // Latch the thread we were called on, primarily for debugging purposes.
+
+    self.clientThread = [NSThread currentThread];
+
+    // Once everything is ready to go, create a data task with the new request.
+
+    self.task = [[[self class] sharedDemux] dataTaskWithRequest:recursiveRequest delegate:self modes:self.modes];
+    assert(self.task != nil);
+
+    [self.task resume];
+}
+
+- (void)stopLoading
+{
+    // The implementation just cancels the current load (if it's still running).
+
+    [[self class] customHTTPProtocol:self logWithFormat:@"stop (elapsed %.1f)", [NSDate timeIntervalSinceReferenceDate] - self.startTime];
+
+    assert(self.clientThread != nil);           // someone must have called -startLoading
+
+    // Check that we're being stopped on the same thread that we were started
+    // on.  Without this invariant things are going to go badly (for example,
+    // run loop sources that got attached during -startLoading may not get
+    // detached here).
+    //
+    // I originally had code here to bounce over to the client thread but that
+    // actually gets complex when you consider run loop modes, so I've nixed it.
+    // Rather, I rely on our client calling us on the right thread, which is what
+    // the following assert is about.
+
+    assert([NSThread currentThread] == self.clientThread);
+
+    [self cancelPendingChallenge];
+    if (self.task != nil) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [self.task cancel];
+            self.task = nil;
+        });
+        // The following ends up calling -URLSession:task:didCompleteWithError: with NSURLErrorDomain / NSURLErrorCancelled,
+        // which specificallys traps and ignores the error.
+    }
+    // Don't nil out self.modes; see property declaration comments for a a discussion of this.
+}
+
+#pragma mark * Authentication challenge handling
+
+/*! Performs the block on the specified thread in one of specified modes.
+ *  \param thread The thread to target; nil implies the main thread.
+ *  \param modes The modes to target; nil or an empty array gets you the default run loop mode.
+ *  \param block The block to run.
+ */
+
+- (void)performOnThread:(NSThread *)thread modes:(NSArray *)modes block:(dispatch_block_t)block
+{
+    // thread may be nil
+    // modes may be nil
+    assert(block != nil);
+
+    if (thread == nil) {
+        thread = [NSThread mainThread];
+    }
+    if ([modes count] == 0) {
+        modes = @[ NSDefaultRunLoopMode ];
+    }
+    [self performSelector:@selector(onThreadPerformBlock:) onThread:thread withObject:[block copy] waitUntilDone:NO modes:modes];
+}
+
+/*! A helper method used by -performOnThread:modes:block:. Runs in the specified context
+ *  and simply calls the block.
+ *  \param block The block to run.
+ */
+
+- (void)onThreadPerformBlock:(dispatch_block_t)block
+{
+    assert(block != nil);
+    block();
+}
+
+/*! Called by our NSURLSession delegate callback to pass the challenge to our delegate.
+ *  \description This simply passes the challenge over to the main thread.
+ *  We do this so that all accesses to pendingChallenge are done from the main thread,
+ *  which avoids the need for extra synchronisation.
+ *
+ *  By the time this runes, the NSURLSession delegate callback has already confirmed with
+ *  the delegate that it wants the challenge.
+ *
+ *  Note that we use the default run loop mode here, not the common modes.  We don't want
+ *  an authorisation dialog showing up on top of an active menu (-:
+ *
+ *  Also, we implement our own 'perform block' infrastructure because Cocoa doesn't have
+ *  one <rdar://problem/17232344> and CFRunLoopPerformBlock is inadequate for the
+ *  return case (where we need to pass in an array of modes; CFRunLoopPerformBlock only takes
+ *  one mode).
+ *  \param challenge The authentication challenge to process; must not be nil.
+ *  \param completionHandler The associated completion handler; must not be nil.
+ */
+
+- (void)didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(ChallengeCompletionHandler)completionHandler
+{
+    assert(challenge != nil);
+    assert(completionHandler != nil);
+    assert([NSThread currentThread] == self.clientThread);
+
+    [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ received", [[challenge protectionSpace] authenticationMethod]];
+
+    [self performOnThread:nil modes:nil block:^{
+        [self mainThreadDidReceiveAuthenticationChallenge:challenge completionHandler:completionHandler];
+    }];
+}
+
+/*! The main thread side of authentication challenge processing.
+ *  \details If there's already a pending challenge, something has gone wrong and
+ *  the routine simply cancels the new challenge.  If our delegate doesn't implement
+ *  the -customHTTPProtocol:canAuthenticateAgainstProtectionSpace: delegate callback,
+ *  we also cancel the challenge.  OTOH, if all goes well we simply call our delegate
+ *  with the challenge.
+ *  \param challenge The authentication challenge to process; must not be nil.
+ *  \param completionHandler The associated completion handler; must not be nil.
+ */
+
+- (void)mainThreadDidReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(ChallengeCompletionHandler)completionHandler
+{
+    assert(challenge != nil);
+    assert(completionHandler != nil);
+    assert([NSThread isMainThread]);
+
+    if (self.pendingChallenge != nil) {
+
+        // Our delegate is not expecting a second authentication challenge before resolving the
+        // first.  Likewise, NSURLSession shouldn't send us a second authentication challenge
+        // before we resolve the first.  If this happens, assert, log, and cancel the challenge.
+        //
+        // Note that we have to cancel the challenge on the thread on which we received it,
+        // namely, the client thread.
+
+        [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ cancelled; other challenge pending", [[challenge protectionSpace] authenticationMethod]];
+        assert(NO);
+        [self clientThreadCancelAuthenticationChallenge:challenge completionHandler:completionHandler];
+    } else {
+        id<CustomHTTPProtocolDelegate>  strongDelegate;
+
+        strongDelegate = [[self class] delegate];
+
+        // Tell the delegate about it.  It would be weird if the delegate didn't support this
+        // selector (it did return YES from -customHTTPProtocol:canAuthenticateAgainstProtectionSpace:
+        // after all), but if it doesn't then we just cancel the challenge ourselves (or the client
+        // thread, of course).
+
+        if ( ! [strongDelegate respondsToSelector:@selector(customHTTPProtocol:canAuthenticateAgainstProtectionSpace:)] ) {
+            [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ cancelled; no delegate method", [[challenge protectionSpace] authenticationMethod]];
+            assert(NO);
+            [self clientThreadCancelAuthenticationChallenge:challenge completionHandler:completionHandler];
+        } else {
+
+            // Remember that this challenge is in progress.
+
+            self.pendingChallenge = challenge;
+            self.pendingChallengeCompletionHandler = completionHandler;
+
+            // Pass the challenge to the delegate.
+
+            [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ passed to delegate", [[challenge protectionSpace] authenticationMethod]];
+            [strongDelegate customHTTPProtocol:self didReceiveAuthenticationChallenge:self.pendingChallenge];
+        }
+    }
+}
+
+/*! Cancels an authentication challenge that hasn't made it to the pending challenge state.
+ *  \details This routine is called as part of various error cases in the challenge handling
+ *  code.  It cancels a challenge that, for some reason, we've failed to pass to our delegate.
+ *
+ *  The routine is always called on the main thread but bounces over to the client thread to
+ *  do the actual cancellation.
+ *  \param challenge The authentication challenge to cancel; must not be nil.
+ *  \param completionHandler The associated completion handler; must not be nil.
+ */
+
+- (void)clientThreadCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(ChallengeCompletionHandler)completionHandler
+{
+    #pragma unused(challenge)
+    assert(challenge != nil);
+    assert(completionHandler != nil);
+    assert([NSThread isMainThread]);
+
+    [self performOnThread:self.clientThread modes:self.modes block:^{
+        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+    }];
+}
+
+/*! Cancels an authentication challenge that /has/ made to the pending challenge state.
+ *  \details This routine is called by -stopLoading to cancel any challenge that might be
+ *  pending when the load is cancelled.  It's always called on the client thread but
+ *  immediately bounces over to the main thread (because .pendingChallenge is a main
+ *  thread only value).
+ */
+
+- (void)cancelPendingChallenge
+{
+    assert([NSThread currentThread] == self.clientThread);
+
+    // Just pass the work off to the main thread.  We do this so that all accesses
+    // to pendingChallenge are done from the main thread, which avoids the need for
+    // extra synchronisation.
+
+    [self performOnThread:nil modes:nil block:^{
+        if (self.pendingChallenge == nil) {
+            // This is not only not unusual, it's actually very typical.  It happens every time you shut down
+            // the connection.  Ideally I'd like to not even call -mainThreadCancelPendingChallenge when
+            // there's no challenge outstanding, but the synchronisation issues are tricky.  Rather than solve
+            // those, I'm just not going to log in this case.
+            //
+            // [[self class] customHTTPProtocol:self logWithFormat:@"challenge not cancelled; no challenge pending"];
+        } else {
+            id<CustomHTTPProtocolDelegate>  strongeDelegate;
+            NSURLAuthenticationChallenge *  challenge;
+
+            strongeDelegate = [[self class] delegate];
+
+            challenge = self.pendingChallenge;
+            self.pendingChallenge = nil;
+            self.pendingChallengeCompletionHandler = nil;
+
+            if ([strongeDelegate respondsToSelector:@selector(customHTTPProtocol:didCancelAuthenticationChallenge:)]) {
+                [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ cancellation passed to delegate", [[challenge protectionSpace] authenticationMethod]];
+                [strongeDelegate customHTTPProtocol:self didCancelAuthenticationChallenge:challenge];
+            } else {
+                [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ cancellation failed; no delegate method", [[challenge protectionSpace] authenticationMethod]];
+                // If we managed to send a challenge to the client but can't cancel it, that's bad.
+                // There's nothing we can do at this point except log the problem.
+                assert(NO);
+            }
+        }
+    }];
+}
+
+- (void)resolveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge withCredential:(NSURLCredential *)credential
+{
+    assert(challenge == self.pendingChallenge);
+    // credential may be nil
+    assert([NSThread isMainThread]);
+    assert(self.clientThread != nil);
+
+    if (challenge != self.pendingChallenge) {
+        [[self class] customHTTPProtocol:self logWithFormat:@"challenge resolution mismatch (%@ / %@)", challenge, self.pendingChallenge];
+        // This should never happen, and we want to know if it does, at least in the debug build.
+        assert(NO);
+    } else {
+        ChallengeCompletionHandler  completionHandler;
+
+        // We clear out our record of the pending challenge and then pass the real work
+        // over to the client thread (which ensures that the challenge is resolved on
+        // the same thread we received it on).
+
+        completionHandler = self.pendingChallengeCompletionHandler;
+        self.pendingChallenge = nil;
+        self.pendingChallengeCompletionHandler = nil;
+
+        [self performOnThread:self.clientThread modes:self.modes block:^{
+            if (credential == nil) {
+                [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ resolved without credential", [[challenge protectionSpace] authenticationMethod]];
+                completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+            } else {
+                [[self class] customHTTPProtocol:self logWithFormat:@"challenge %@ resolved with <%@ %p>", [[challenge protectionSpace] authenticationMethod], [credential class], credential];
+                completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+            }
+        }];
+    }
+}
+
+#pragma mark * NSURLSession delegate callbacks
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)newRequest completionHandler:(void (^)(NSURLRequest *))completionHandler
+{
+    NSMutableURLRequest *    redirectRequest;
+
+    #pragma unused(session)
+    #pragma unused(task)
+    assert(task == self.task);
+    assert(response != nil);
+    assert(newRequest != nil);
+    #pragma unused(completionHandler)
+    assert(completionHandler != nil);
+    assert([NSThread currentThread] == self.clientThread);
+
+    [[self class] customHTTPProtocol:self logWithFormat:@"will redirect from %@ to %@", [response URL], [newRequest URL]];
+
+    // The new request was copied from our old request, so it has our magic property.  We actually
+    // have to remove that so that, when the client starts the new request, we see it.  If we
+    // don't do this then we never see the new request and thus don't get a chance to change
+    // its caching behaviour.
+    //
+    // We also cancel our current connection because the client is going to start a new request for
+    // us anyway.
+
+    assert([[self class] propertyForKey:kOurRecursiveRequestFlagProperty inRequest:newRequest] != nil);
+
+    redirectRequest = [newRequest mutableCopy];
+    [[self class] removePropertyForKey:kOurRecursiveRequestFlagProperty inRequest:redirectRequest];
+
+    // Tell the client about the redirect.
+
+    [[self client] URLProtocol:self wasRedirectedToRequest:redirectRequest redirectResponse:response];
+
+    // Stop our load.  The CFNetwork infrastructure will create a new NSURLProtocol instance to run
+    // the load of the redirect.
+
+    // The following ends up calling -URLSession:task:didCompleteWithError: with NSURLErrorDomain / NSURLErrorCancelled,
+    // which specificallys traps and ignores the error.
+
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self.task cancel];
+        self.task = nil;
+    });
+
+    [[self client] URLProtocol:self didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil]];
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+    BOOL        result;
+    id<CustomHTTPProtocolDelegate> strongeDelegate;
+
+    #pragma unused(session)
+    #pragma unused(task)
+    assert(task == self.task);
+    assert(challenge != nil);
+    assert(completionHandler != nil);
+    assert([NSThread currentThread] == self.clientThread);
+
+    // Ask our delegate whether it wants this challenge.  We do this from this thread, not the main thread,
+    // to avoid the overload of bouncing to the main thread for challenges that aren't going to be customised
+    // anyway.
+
+    strongeDelegate = [[self class] delegate];
+
+    result = NO;
+    if ([strongeDelegate respondsToSelector:@selector(customHTTPProtocol:canAuthenticateAgainstProtectionSpace:)]) {
+        result = [strongeDelegate customHTTPProtocol:self canAuthenticateAgainstProtectionSpace:[challenge protectionSpace]];
+    }
+
+    // If the client wants the challenge, kick off that process.  If not, resolve it by doing the default thing.
+
+    if (result) {
+        [[self class] customHTTPProtocol:self logWithFormat:@"can authenticate %@", [[challenge protectionSpace] authenticationMethod]];
+
+        [self didReceiveAuthenticationChallenge:challenge completionHandler:completionHandler];
+    } else {
+        [[self class] customHTTPProtocol:self logWithFormat:@"cannot authenticate %@", [[challenge protectionSpace] authenticationMethod]];
+
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+{
+    NSURLCacheStoragePolicy cacheStoragePolicy;
+    NSInteger               statusCode;
+
+    #pragma unused(session)
+    #pragma unused(dataTask)
+    assert(dataTask == self.task);
+    assert(response != nil);
+    assert(completionHandler != nil);
+    assert([NSThread currentThread] == self.clientThread);
+
+    // Pass the call on to our client.  The only tricky thing is that we have to decide on a
+    // cache storage policy, which is based on the actual request we issued, not the request
+    // we were given.
+
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+        cacheStoragePolicy = CacheStoragePolicyForRequestAndResponse(self.task.originalRequest, (NSHTTPURLResponse *) response);
+        statusCode = [((NSHTTPURLResponse *) response) statusCode];
+    } else {
+        assert(NO);
+        cacheStoragePolicy = NSURLCacheStorageNotAllowed;
+        statusCode = 42;
+    }
+
+    [[self class] customHTTPProtocol:self logWithFormat:@"received response %zd / %@ with cache storage policy %zu", (ssize_t) statusCode, [response URL], (size_t) cacheStoragePolicy];
+
+    [[self client] URLProtocol:self didReceiveResponse:response cacheStoragePolicy:cacheStoragePolicy];
+
+    completionHandler(NSURLSessionResponseAllow);
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+{
+    #pragma unused(session)
+    #pragma unused(dataTask)
+    assert(dataTask == self.task);
+    assert(data != nil);
+    assert([NSThread currentThread] == self.clientThread);
+
+    // Just pass the call on to our client.
+
+    [[self class] customHTTPProtocol:self logWithFormat:@"received %zu bytes of data", (size_t) [data length]];
+
+    [[self client] URLProtocol:self didLoadData:data];
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask willCacheResponse:(NSCachedURLResponse *)proposedResponse completionHandler:(void (^)(NSCachedURLResponse *))completionHandler
+{
+    #pragma unused(session)
+    #pragma unused(dataTask)
+    assert(dataTask == self.task);
+    assert(proposedResponse != nil);
+    assert(completionHandler != nil);
+    assert([NSThread currentThread] == self.clientThread);
+
+    // We implement this delegate callback purely for the purposes of logging.
+
+    [[self class] customHTTPProtocol:self logWithFormat:@"will cache response"];
+
+    completionHandler(proposedResponse);
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+    // An NSURLSession delegate callback.  We pass this on to the client.
+{
+    #pragma unused(session)
+    #pragma unused(task)
+    assert( (self.task == nil) || (task == self.task) );        // can be nil in the 'cancel from -stopLoading' case
+    assert([NSThread currentThread] == self.clientThread);
+
+    // Just log and then, in most cases, pass the call on to our client.
+
+    if (error == nil) {
+        [[self class] customHTTPProtocol:self logWithFormat:@"success"];
+
+        [[self client] URLProtocolDidFinishLoading:self];
+    } else if ( [[error domain] isEqual:NSURLErrorDomain] && ([error code] == NSURLErrorCancelled) ) {
+        // Do nothing.  This happens in two cases:
+        //
+        // o during a redirect, in which case the redirect code has already told the client about
+        //   the failure
+        //
+        // o if the request is cancelled by a call to -stopLoading, in which case the client doesn't
+        //   want to know about the failure
+    } else if ( [error code] == NSURLErrorNetworkConnectionLost && task != nil ) {
+        [[self class] customHTTPProtocol:self logWithFormat:@"lost connection on url %@", [[task currentRequest] URL]];
+        // Restart task
+        NSMutableURLRequest* recursiveRequest = [[task currentRequest] mutableCopy];
+        [self.task cancel];
+        [[self class] removePropertyForKey:kOurRecursiveRequestFlagProperty inRequest:recursiveRequest];
+        self.task = [[[self class] sharedDemux] dataTaskWithRequest:recursiveRequest delegate:self modes:self.modes];
+        [self.task resume];
+    } else {
+        [[self class] customHTTPProtocol:self logWithFormat:@"error %@ / %d", [error domain], (int) [error code]];
+
+        [[self client] URLProtocol:self didFailWithError:error];
+    }
+
+    // We don't need to clean up the connection here; the system will call, or has already called,
+    // -stopLoading to do that.
+}
+
+@end

--- a/src/ios/QNSURLSessionDemux.h
+++ b/src/ios/QNSURLSessionDemux.h
@@ -1,0 +1,91 @@
+/*
+     File: QNSURLSessionDemux.h
+ Abstract: A general class to demux NSURLSession delegate callbacks.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import <Foundation/Foundation.h>
+
+/*! A simple class for demultiplexing NSURLSession delegate callbacks to a per-task delegate object.
+
+    You initialise the class with a session configuration. After that you can create data tasks 
+    within that session by calling -dataTaskWithRequest:delegate:modes:.  Any delegate callbacks 
+    for that data task are redirected to the delegate on the thread that created the task in 
+    one of the specified run loop modes.  That thread must run its run loop in order to get 
+    these callbacks.
+*/
+
+@interface QNSURLSessionDemux : NSObject
+
+/*! Create a demultiplex for the specified session configuration.
+ *  \param configuration The session configuration to use; if nil, a default session is created.
+ *  \returns An initialised instance.
+ */
+
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration;
+
+@property (atomic, copy,   readonly ) NSURLSessionConfiguration *   configuration;  ///< A copy of the configuration passed to -initWithConfiguration:.
+@property (atomic, strong, readonly ) NSURLSession *                session;        ///< The session created from the configuration passed to -initWithConfiguration:.
+
+/*! Creates a new data task whose delegate callbacks are routed to the supplied delegate.
+ *  \details The callbacks are run on the current thread (that is, the thread that called this 
+ *  method) in the specified modes.
+ *
+ *  The delegate is retained until the task completes, that is, until after your 
+ *  -URLSession:task:didCompleteWithError: delegate callback returns.
+ *
+ *  The returned task is suspend.  You must resume the returned task for the task to 
+ *  make progress.  Furthermore, it's not safe to simply discard the returned task 
+ *  because in that case the task's delegate is never released.
+ *
+ *  \param request The request that the data task executes; must not be nil.
+ *  \param delegate The delegate to receive the data task's delegate callbacks; must not be nil.
+ *  \param modes The run loop modes in which to run the data task's delegate callbacks; if nil or 
+ *  empty, the default run loop mode (NSDefaultRunLoopMode is used).
+ *  \returns A suspended data task that you must resume.
+ */
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request delegate:(id<NSURLSessionDataDelegate>)delegate modes:(NSArray *)modes;
+
+@end

--- a/src/ios/QNSURLSessionDemux.m
+++ b/src/ios/QNSURLSessionDemux.m
@@ -1,0 +1,318 @@
+/*
+     File: QNSURLSessionDemux.m
+ Abstract: A general class to demux NSURLSession delegate callbacks.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import "QNSURLSessionDemux.h"
+
+@interface QNSURLSessionDemuxTaskInfo : NSObject
+
+- (instancetype)initWithTask:(NSURLSessionDataTask *)task delegate:(id<NSURLSessionDataDelegate>)delegate modes:(NSArray *)modes;
+
+@property (atomic, strong, readonly ) NSURLSessionDataTask *        task;
+@property (atomic, strong, readonly ) id<NSURLSessionDataDelegate>  delegate;
+@property (atomic, strong, readonly ) NSThread *                    thread;
+@property (atomic, copy,   readonly ) NSArray *                     modes;
+
+- (void)performBlock:(dispatch_block_t)block;
+
+- (void)invalidate;
+
+@end
+
+@interface QNSURLSessionDemuxTaskInfo ()
+
+@property (atomic, strong, readwrite) id<NSURLSessionDataDelegate>  delegate;
+@property (atomic, strong, readwrite) NSThread *                    thread;
+
+@end
+
+@implementation QNSURLSessionDemuxTaskInfo
+
+- (instancetype)initWithTask:(NSURLSessionDataTask *)task delegate:(id<NSURLSessionDataDelegate>)delegate modes:(NSArray *)modes
+{
+    assert(task != nil);
+    assert(delegate != nil);
+    assert(modes != nil);
+    
+    self = [super init];
+    if (self != nil) {
+        self->_task = task;
+        self->_delegate = delegate;
+        self->_thread = [NSThread currentThread];
+        self->_modes = [modes copy];
+    }
+    return self;
+}
+
+- (void)performBlock:(dispatch_block_t)block
+{
+    assert(self.delegate != nil);
+    assert(self.thread != nil);
+    [self performSelector:@selector(performBlockOnClientThread:) onThread:self.thread withObject:[block copy] waitUntilDone:NO modes:self.modes];
+}
+
+- (void)performBlockOnClientThread:(dispatch_block_t)block
+{
+    assert([NSThread currentThread] == self.thread);
+    block();
+}
+
+- (void)invalidate
+{
+    self.delegate = nil;
+    self.thread = nil;
+}
+
+@end
+
+@interface QNSURLSessionDemux () <NSURLSessionDataDelegate>
+
+@property (atomic, strong, readonly ) NSMutableDictionary * taskInfoByTaskID;       // keys NSURLSessionTask taskIdentifier, values are SessionManager
+@property (atomic, strong, readonly ) NSOperationQueue *    sessionDelegateQueue;
+
+@end
+
+@implementation QNSURLSessionDemux
+
+- (instancetype)init
+{
+    return [self initWithConfiguration:nil];
+}
+
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
+{
+    // configuration may be nil
+    self = [super init];
+    if (self != nil) {
+        if (configuration == nil) {
+            configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        }
+        self->_configuration = [configuration copy];
+
+        self->_taskInfoByTaskID = [[NSMutableDictionary alloc] init];
+
+        self->_sessionDelegateQueue = [[NSOperationQueue alloc] init];
+        [self->_sessionDelegateQueue setMaxConcurrentOperationCount:1];
+        [self->_sessionDelegateQueue setName:@"QNSURLSessionDemux"];
+
+        self->_session = [NSURLSession sessionWithConfiguration:self->_configuration delegate:self delegateQueue:self->_sessionDelegateQueue];
+        self->_session.sessionDescription = @"QNSURLSessionDemux";
+    }
+    return self;
+}
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request delegate:(id<NSURLSessionDataDelegate>)delegate modes:(NSArray *)modes
+{
+    NSURLSessionDataTask *          task;
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+
+    assert(request != nil);
+    assert(delegate != nil);
+    // modes may be nil
+    
+    if ([modes count] == 0) {
+        modes = @[ NSDefaultRunLoopMode ];
+    }
+    
+    task = [self.session dataTaskWithRequest:request];
+    assert(task != nil);
+    
+    taskInfo = [[QNSURLSessionDemuxTaskInfo alloc] initWithTask:task delegate:delegate modes:modes];
+    
+    @synchronized (self) {
+        self.taskInfoByTaskID[@(task.taskIdentifier)] = taskInfo;
+    }
+    
+    return task;
+}
+
+- (QNSURLSessionDemuxTaskInfo *)taskInfoForTask:(NSURLSessionTask *)task
+{
+    QNSURLSessionDemuxTaskInfo *    result;
+    
+    assert(task != nil);
+    
+    @synchronized (self) {
+        result = self.taskInfoByTaskID[@(task.taskIdentifier)];
+        assert(result != nil);
+    }
+    return result;
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)newRequest completionHandler:(void (^)(NSURLRequest *))completionHandler
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:task];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session task:task willPerformHTTPRedirection:response newRequest:newRequest completionHandler:completionHandler];
+        }];
+    } else {
+        completionHandler(newRequest);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:task];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didReceiveChallenge:completionHandler:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session task:task didReceiveChallenge:challenge completionHandler:completionHandler];
+        }];
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task needNewBodyStream:(void (^)(NSInputStream *bodyStream))completionHandler
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:task];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:needNewBodyStream:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session task:task needNewBodyStream:completionHandler];
+        }];
+    } else {
+        completionHandler(nil);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:task];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session task:task didSendBodyData:bytesSent totalBytesSent:totalBytesSent totalBytesExpectedToSend:totalBytesExpectedToSend];
+        }];
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:task];
+
+    // This is our last delegate callback so we remove our task info record.
+    
+    @synchronized (self) {
+        [self.taskInfoByTaskID removeObjectForKey:@(taskInfo.task.taskIdentifier)];
+    }
+
+    // Call the delegate if required.  In that case we invalidate the task info on the client thread 
+    // after calling the delegate, otherwise the client thread side of the -performBlock: code can 
+    // find itself with an invalidated task info.
+    
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session task:task didCompleteWithError:error];
+            [taskInfo invalidate];
+        }];
+    } else {
+        [taskInfo invalidate];
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:dataTask];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didReceiveResponse:completionHandler:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session dataTask:dataTask didReceiveResponse:response completionHandler:completionHandler];
+        }];
+    } else {
+        completionHandler(NSURLSessionResponseAllow);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:dataTask];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didBecomeDownloadTask:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session dataTask:dataTask didBecomeDownloadTask:downloadTask];
+        }];
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:dataTask];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:didReceiveData:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session dataTask:dataTask didReceiveData:data];
+        }];
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask willCacheResponse:(NSCachedURLResponse *)proposedResponse completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler
+{
+    QNSURLSessionDemuxTaskInfo *    taskInfo;
+    
+    taskInfo = [self taskInfoForTask:dataTask];
+    if ([taskInfo.delegate respondsToSelector:@selector(URLSession:dataTask:willCacheResponse:completionHandler:)]) {
+        [taskInfo performBlock:^{
+            [taskInfo.delegate URLSession:session dataTask:dataTask willCacheResponse:proposedResponse completionHandler:completionHandler];
+        }];
+    } else {
+        completionHandler(proposedResponse);
+    }
+}
+
+@end
+

--- a/src/ios/ThreadInfo.h
+++ b/src/ios/ThreadInfo.h
@@ -1,0 +1,69 @@
+/*
+     File: ThreadInfo.h
+ Abstract: Records information about a thread for logging purposes.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import <Foundation/Foundation.h>
+
+/*! Records information about a thread.  This is a simple 'data carrier' class, with no 
+ *  brains at all, used by the app's logging code.
+ */
+
+@interface ThreadInfo : NSObject
+
+/*! Initialises the object with the specified values.
+ *  \param tid The globally unique thread ID.
+ *  \param number The thread number inside this app.
+ *  \param name The name of the thread; must not be nil.
+ *  \returns An initialised instance.
+ */
+
+- (instancetype)initWithThreadID:(uint64_t)tid number:(NSUInteger)number name:(NSString *)name;
+
+@property (atomic, assign, readonly ) uint64_t      tid;            ///< The globally unique thread ID.
+@property (atomic, assign, readonly ) NSUInteger    number;         ///< The thread number inside this app.
+@property (atomic, copy,   readonly ) NSString *    name;           ///< The name of the thread; will not be nil.
+
+@end

--- a/src/ios/ThreadInfo.m
+++ b/src/ios/ThreadInfo.m
@@ -1,0 +1,69 @@
+/*
+     File: ThreadInfo.m
+ Abstract: Records information about a thread for logging purposes.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import "ThreadInfo.h"
+
+@implementation ThreadInfo
+
+- (instancetype)initWithThreadID:(uint64_t)tid number:(NSUInteger)number name:(NSString *)name
+{
+    assert(name != nil);
+    self = [super init];
+    if (self != nil) {
+        self->_tid = tid;
+        self->_number = number;
+        self->_name = [name copy];
+    }
+    return self;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %zu %#llx %@", [self class], (size_t) self->_number, self->_tid, self->_name];
+}
+
+@end

--- a/src/ios/WebViewController.h
+++ b/src/ios/WebViewController.h
@@ -1,0 +1,96 @@
+/*
+     File: WebViewController.h
+ Abstract: Main web view controller.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+@import UIKit;
+
+@protocol WebViewControllerDelegate;
+
+/*! A view controller to run a web view.  The implementation includes a number 
+ *  of interesting features, including:
+ *
+ *  - a Sites button, to display a pre-configured list of web sites (from "root.html")
+ *  
+ *  - the ability to download and install (via a delegate callback) a custom 
+ *    root certificate (trusted anchor)
+ */
+
+@interface WebViewController : UIViewController
+
+@property (nonatomic, weak,   readwrite) id<WebViewControllerDelegate>  delegate;           ///< The controller delegate.
+
+- (BOOL)parseAndInstallCertificateData:(NSData *)data error:(__autoreleasing NSError **)errorPtr;
+- (void)logWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
+
+@end
+
+/*! The protocol for the WebViewController delegate.
+ */
+
+@protocol WebViewControllerDelegate <NSObject>
+
+@optional
+
+/*! Called by the WebViewController to add a certificate as a trusted anchor.
+ *  Will be called on the main thread.
+ *  \param controller The controller instance; will not be nil.
+ *  \param anchor The certificate to add; will not be NULL.
+ *  \param errorPtr If not NULL then, on error, set *errorPtr to the actual error.
+ *  \returns Return YES for success, NO for failure.
+ */
+
+- (BOOL)webViewController:(WebViewController *)controller addTrustedAnchor:(SecCertificateRef)anchor error:(NSError **)errorPtr;
+
+/*! Called by the WebViewController to log various actions. 
+ *  Will be called on the main thread.
+ *  \param controller The controller instance; will not be nil.
+ *  \param format A standard NSString-style format string; will not be nil.
+ *  \param arguments Arguments for that format string.
+ */
+
+- (void)webViewController:(WebViewController *)controller logWithFormat:(NSString *)format arguments:(va_list)arguments;
+
+@end

--- a/src/ios/WebViewController.m
+++ b/src/ios/WebViewController.m
@@ -1,0 +1,174 @@
+/*
+     File: WebViewController.m
+ Abstract: Main web view controller.
+  Version: 1.1
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2014 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#import "WebViewController.h"
+
+@import Security;
+
+@interface WebViewController () <UIWebViewDelegate>
+
+// stuff for IB
+
+@property (nonatomic, strong, readwrite) IBOutlet UIWebView *   webView;
+
+// private properties
+
+@property (nonatomic, strong, readwrite) NSURLSessionDataTask * installDataTask;
+
+@end
+
+@implementation WebViewController
+
+- (void)dealloc
+{
+    // All of these should be nil because the connection retains its delegate (that is, us) 
+    // until it completes, and we clean these up when the connection completes.
+    
+    assert(self->_installDataTask == nil);
+}
+
+/*! Called to log various bits of information.  Will be called on the main thread.
+ *  \param format A standard NSString-style format string; will not be nil.
+ */
+
+- (void)logWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2)
+{
+    id<WebViewControllerDelegate>   strongDelegate;
+
+    assert(format != nil);
+    
+    strongDelegate = self.delegate;
+    if ([strongDelegate respondsToSelector:@selector(webViewController:logWithFormat:arguments:)]) {
+        va_list     arguments;
+        
+        va_start(arguments, format);
+        [strongDelegate webViewController:self logWithFormat:format arguments:arguments];
+        va_end(arguments);
+    }
+}
+
+/*! The error domain used by our installation error codes.
+ */
+
+static NSString * WebViewControllerInstallErrorDomain = @"WebViewControllerInstallErrorDomain";
+
+/*! Our installation error codes.  Note that (positive) HTTP status codes are also possible.
+ */
+
+enum WebViewControllerInstallErrorCode {
+    // positive numbers are HTTP status codes
+    WebViewControllerInstallErrorUnsupportedMIMEType   = -1, 
+    WebViewControllerInstallErrorCertificateDataTooBig = -2,
+    WebViewControllerInstallErrorCertificateDataBad    = -3, 
+    WebViewControllerInstallErrorNowhereToInstall      = -4
+};
+
+/*! Returns an error object in the domain WebViewControllerInstallErrorDomain with 
+ *  the specified error code
+ *  \param code The code to use for the error.
+ */
+
+- (NSError *)constructInstallErrorWithCode:(NSInteger)code
+{
+    assert(code != 0);
+
+    return [NSError errorWithDomain:WebViewControllerInstallErrorDomain code:code userInfo:nil];
+}
+
+/*! Create and installs a certificate from the data returned by the install data task.
+ *  \param data The data returned by the install data task; must not be nil.
+ *  \param errorPtr If not NULL then, on error, *errorPtr will be the actual error.
+ *  \returns Returns YES on success, NO on failure.
+ */
+
+- (BOOL)parseAndInstallCertificateData:(NSData *)data error:(__autoreleasing NSError **)errorPtr
+{
+    NSError *           error;
+    SecCertificateRef   anchor;
+
+    assert(data != nil);
+    // errorPtr may be NULL
+    assert([NSThread isMainThread]);
+    
+    // Try to create a certificate from the data we downloaded.  If that 
+    // succeeds, tell our delegate.
+    
+    error = nil;
+    anchor = SecCertificateCreateWithData(NULL, (__bridge CFDataRef) data);
+    if (anchor == nil) {
+        error = [self constructInstallErrorWithCode:WebViewControllerInstallErrorCertificateDataBad];
+    }
+    if (error == nil) {
+        id<WebViewControllerDelegate>   strongDelegate;
+        
+        strongDelegate = self.delegate;
+        if ( ! [strongDelegate respondsToSelector:@selector(webViewController:addTrustedAnchor:error:)] ) {
+            error = [self constructInstallErrorWithCode:WebViewControllerInstallErrorNowhereToInstall];
+        } else {
+            BOOL                            success;
+            NSError *                       delegateError;
+
+            success = [strongDelegate webViewController:self addTrustedAnchor:anchor error:&delegateError];
+            if ( ! success ) {
+                error = delegateError;
+            }
+        }
+    }
+
+    // Clean up.
+    
+    if (anchor != NULL) {
+        CFRelease(anchor);
+    }
+    if ( (error != nil) && (errorPtr != NULL) ) {
+        *errorPtr = error;
+    }
+    
+    return (error == nil);
+}
+
+@end


### PR DESCRIPTION
@orcasgit/orcas-developers Please review. This leans heavily on the [CustomHTTPProtocol example](https://developer.apple.com/library/ios/samplecode/CustomHTTPProtocol/Introduction/Intro.html) by Apple, though I was able to simplify a few things by getting the certificate from a file instead of a URL as in their example. This is what Apple themselves [recommend we do](https://developer.apple.com/library/mac/technotes/tn2232/_index.html#//apple_ref/doc/uid/DTS40012884-CH1-SECUIWEBVIEW) in order to get `UIWebView` to trust other certificates.

The android stuff is here too (unchanged) because I thought it made sense to merge to the master branch of this repo, and I'll redo my PR against upstream to include both Android and iOS support.
